### PR TITLE
Display markdown files from anywhere in the repo when pulled from Git

### DIFF
--- a/custom-generator-codelab/src/index.js
+++ b/custom-generator-codelab/src/index.js
@@ -350,13 +350,22 @@ async function handleClone() {
     // Import Java and Markdown files into the Online-IDE.
     importJavaFilesToIDE({ ...files.java, ...files.md });
 
-    // Auto-select the first file if none is currently selected.
-    if (!IdeBridge.selected_file_name) {
-      const ideAccess = globalThis.online_ide_access?.getIDE?.('Java');
-      const ideFiles = ideAccess?.getFiles?.() ?? [];
+    // After importing, prefer displaying a markdown file if one exists.
+    // We use fileExplorer.selectFile directly because IdeBridge.fileSelected
+    // intentionally ignores .md files (they are view-only panels).
+    const ideAccess = globalThis.online_ide_access?.getIDE?.('Java');
+    const ideFiles = ideAccess?.getFiles?.() ?? [];
+    const mdFile = ideFiles.find(f => f.getName().toLowerCase().endsWith('.md'));
+    if (mdFile) {
+      const ide = ideAccess.ide;
+      const internalFile = mdFile.file ?? mdFile;
+      // Select the treeview node so it gets highlighted in the file explorer.
+      const node = ide?.fileExplorer?.treeview?.nodes?.find(n => n.externalObject === internalFile);
+      if (node) ide.fileExplorer.treeview.selectNodeAndSetFocus(node, false);
+      ide?.fileExplorer?.selectFile?.(internalFile);
+    } else if (!IdeBridge.selected_file_name) {
       if (ideFiles.length > 0) {
-        const firstName = ideFiles[0].getName();
-        IdeBridge.fileSelected(firstName);
+        IdeBridge.fileSelected(ideFiles[0].getName());
       }
     } else {
       load(ws);

--- a/custom-generator-codelab/src/index.js
+++ b/custom-generator-codelab/src/index.js
@@ -198,8 +198,13 @@ function setupListeners(workspace) {
  * Called whenever the Blockly blocks change meaningfully.
  * Clears stale constructor data, regenerates Java code, transforms it,
  * and pushes the result to the online IDE.
+ * If the IDE is currently showing a Markdown file, it is switched back to
+ * the last active Java file first.
  */
 export function onBlocksChange() {
+  // If the IDE is showing a .md file, switch it back to the Java file.
+  IdeBridge.ensureJavaFileActive();
+
   IdeBridge.syncClassNameFromIDE();
   LocalStorageManager.clearConstructors(getClassName());
 
@@ -342,8 +347,8 @@ async function handleClone() {
     const files = await GitService.clone(rawUrl, finalPassword);
     dismiss();
 
-    // Import Java files into the Online-IDE.
-    importJavaFilesToIDE(files.java);
+    // Import Java and Markdown files into the Online-IDE.
+    importJavaFilesToIDE({ ...files.java, ...files.md });
 
     // Auto-select the first file if none is currently selected.
     if (!IdeBridge.selected_file_name) {
@@ -360,7 +365,7 @@ async function handleClone() {
 
     updateGitButtonStates();
 
-    const fileCount = Object.keys(files.xml).length + Object.keys(files.java).length;
+    const fileCount = Object.keys(files.xml).length + Object.keys(files.java).length + Object.keys(files.md).length;
     await GitDialog.showMessage(
       'Erfolgreich geklont',
       `${fileCount} Datei(en) importiert.`,
@@ -381,7 +386,7 @@ async function handlePull() {
     const files = await GitService.pull();
     dismiss();
 
-    importJavaFilesToIDE(files.java);
+    importJavaFilesToIDE({ ...files.java, ...files.md });
 
     if (IdeBridge.selected_file_name) {
       load(ws);
@@ -390,7 +395,7 @@ async function handlePull() {
 
     updateGitButtonStates();
 
-    const fileCount = Object.keys(files.xml).length + Object.keys(files.java).length;
+    const fileCount = Object.keys(files.xml).length + Object.keys(files.java).length + Object.keys(files.md).length;
     await GitDialog.showMessage(
       'Pull erfolgreich',
       `${fileCount} Datei(en) aktualisiert.`,
@@ -448,7 +453,7 @@ function importJavaFilesToIDE(javaFiles) {
   // ── Remove IDE files that no longer exist in the repo ─────────────────
   for (const ideFile of ideFiles) {
     const name = ideFile.getName();
-    if (name.endsWith('.java') && !pulledNames.has(name)) {
+    if ((name.endsWith('.java') || name.endsWith('.md')) && !pulledNames.has(name)) {
       const ide = ideAccess.ide;
       // ideFile wraps the internal file object; access it via .file
       const internalFile = ideFile.file ?? ideFile;
@@ -459,9 +464,9 @@ function importJavaFilesToIDE(javaFiles) {
         ide.fileExplorer.removeFile(internalFile);
       }
       // Also clean up the corresponding Blockly workspace from localStorage.
-      IdeBridge.fileDeleted(name);
+      if (name.endsWith('.java')) IdeBridge.fileDeleted(name);
       structureChanged = true;
-      console.log(`Git: Java-Datei „${name}" aus IDE entfernt.`);
+      console.log(`Git: Datei „${name}" aus IDE entfernt.`);
     }
   }
 
@@ -484,10 +489,10 @@ function importJavaFilesToIDE(javaFiles) {
           ide.fileExplorer.addFile(file);
         }
         structureChanged = true;
-        console.log(`Git: Java-Datei „${fileName}" in IDE angelegt.`);
+        console.log(`Git: Datei „${fileName}" in IDE angelegt.`);
       } else {
         console.warn(
-          `Git: Java-Datei „${fileName}" existiert nicht in der IDE – ` +
+          `Git: Datei „${fileName}" existiert nicht in der IDE – ` +
           'bitte manuell anlegen und erneut pullen.',
         );
       }

--- a/custom-generator-codelab/src/styles/pane.css
+++ b/custom-generator-codelab/src/styles/pane.css
@@ -79,7 +79,7 @@
     display: flex;
     flex-direction: column;
     min-height: 0;
-    gap: 10px;
+    gap: 12px;
 }
 
 /* ── Draggable dividers ── */

--- a/custom-generator-codelab/src/utils/GitService.js
+++ b/custom-generator-codelab/src/utils/GitService.js
@@ -403,13 +403,42 @@ export class GitService {
   // ── File I/O helpers ─────────────────────────────────────────────────────
 
   /**
+   * Recursively collects all .md files under a directory into `mdMap`.
+   * Keys are the filename only (basename), values are the UTF-8 content.
+   * Dotfiles and dot-directories are skipped.
+   * @param {LightningFS} fs
+   * @param {string} dirPath  absolute path inside the virtual FS
+   * @param {Object<string,string>} mdMap  accumulator
+   */
+  static async _collectMdFiles(fs, dirPath, mdMap) {
+    let entries;
+    try {
+      entries = await fs.promises.readdir(dirPath);
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (entry.startsWith('.')) continue;
+      const fullPath = `${dirPath}/${entry}`;
+      const stat = await fs.promises.stat(fullPath);
+      if (stat.isDirectory()) {
+        await this._collectMdFiles(fs, fullPath, mdMap);
+      } else if (entry.endsWith('.md')) {
+        const content = new TextDecoder().decode(await fs.promises.readFile(fullPath));
+        // Use the basename as key; later entries with the same name overwrite earlier ones.
+        mdMap[entry] = content;
+      }
+    }
+  }
+
+  /**
    * Reads all tracked files (non-dotfiles, non-directories) from the repo
-   * and categorises them into xml and java buckets.
+   * and categorises them into xml, java, and md buckets.
    *
-   * XML files are immediately persisted to localStorage; Java files are
-   * returned to the caller so the IDE bridge can inject them.
+   * XML files are immediately persisted to localStorage; Java files and
+   * Markdown files are returned to the caller so the IDE bridge can inject them.
    *
-   * @returns {Promise<{ xml: Object<string,string>, java: Object<string,string> }>}
+   * @returns {Promise<{ xml: Object<string,string>, java: Object<string,string>, md: Object<string,string> }>}
    */
   static async _readRepoFiles() {
     const fs = this._getFs();
@@ -424,7 +453,7 @@ export class GitService {
       entries = [];
     }
 
-    const result = { xml: {}, java: {} };
+    const result = { xml: {}, java: {}, md: {} };
 
     for (const entry of entries) {
       if (entry.startsWith('.')) continue;
@@ -449,8 +478,13 @@ export class GitService {
         result.xml[entry] = content;
       } else if (entry.endsWith('.java')) {
         result.java[entry] = content;
+      } else if (entry.endsWith('.md')) {
+        result.md[entry] = content;
       }
     }
+
+    // Also collect .md files from anywhere in the repo tree (outside src/).
+    await this._collectMdFiles(fs, this.REPO_DIR, result.md);
 
     // Remove XML entries from localStorage that no longer exist in the repo.
     const repoXmlKeys = new Set(Object.keys(result.xml));

--- a/custom-generator-codelab/src/utils/GitService.js
+++ b/custom-generator-codelab/src/utils/GitService.js
@@ -478,8 +478,6 @@ export class GitService {
         result.xml[entry] = content;
       } else if (entry.endsWith('.java')) {
         result.java[entry] = content;
-      } else if (entry.endsWith('.md')) {
-        result.md[entry] = content;
       }
     }
 

--- a/custom-generator-codelab/src/utils/IdeBridge.js
+++ b/custom-generator-codelab/src/utils/IdeBridge.js
@@ -146,6 +146,16 @@ export class IdeBridge {
    * onBlocksChange() so that generated code always lands in the Java editor.
    */
   static ensureJavaFileActive() {
+    // Backwards-compatible wrapper; prefer switchToLastJavaFileIfNeeded().
+    this.switchToLastJavaFileIfNeeded();
+  }
+
+  /**
+   * If the IDE is currently displaying a non-target file (for example, a
+   * Markdown info panel), switch it back to the last active Java file so
+   * that generated code is written into the correct editor tab.
+   */
+  static switchToLastJavaFileIfNeeded() {
     if (!globalThis.online_ide_access) return;
     const ideAccess = globalThis.online_ide_access.getIDE?.('Java');
     if (!ideAccess) return;

--- a/custom-generator-codelab/src/utils/IdeBridge.js
+++ b/custom-generator-codelab/src/utils/IdeBridge.js
@@ -8,6 +8,12 @@ import { onBlocksChange } from '../index.js';
 export class IdeBridge {
   static selected_file_name = '';
 
+  /**
+   * The last Java file the user had active, so we can switch back to it
+   * when Blockly changes while a Markdown file is shown.
+   */
+  static last_java_file_name = '';
+
   static syncClassNameFromIDE() {
     let className = '';
     const fileName = this.selected_file_name;
@@ -112,8 +118,18 @@ export class IdeBridge {
    */
   static fileSelected(fileName) {
     //console.log(`IdeBridge: file selected ${fileName}`);
+
+    // Markdown files are read-only info panels – Blockly ignores them.
+    // Keep showing the last active Java workspace and don't push code.
+    if (fileName.endsWith('.md')) {
+      return;
+    }
+
     // Update the plain global property so save/load use the correct storage key.
     this.selected_file_name = fileName;
+    if (fileName.endsWith('.java')) {
+      this.last_java_file_name = fileName;
+    }
 
     // Load the saved Blockly workspace for this file.
     //console.log('starting to load workspace for ' + fileName);
@@ -122,5 +138,37 @@ export class IdeBridge {
     // Sync the class name used by the code generator.
     this.syncClassNameFromIDE();
     onBlocksChange();
+  }
+
+  /**
+   * If the IDE is currently displaying a Markdown file, programmatically
+   * switch it back to the last active Java file.  Called at the start of
+   * onBlocksChange() so that generated code always lands in the Java editor.
+   */
+  static ensureJavaFileActive() {
+    if (!globalThis.online_ide_access) return;
+    const ideAccess = globalThis.online_ide_access.getIDE?.('Java');
+    if (!ideAccess) return;
+    const ide = ideAccess.ide;
+    if (!ide?.fileExplorer) return;
+
+    // Check whether the IDE is currently showing something that is NOT our
+    // active Java file (e.g. it's showing a .md file).
+    const targetName = this.selected_file_name || this.last_java_file_name;
+    if (!targetName) return;
+
+    // Find the internal file object matching our target Java file.
+    const wrappedFiles = ideAccess.getFiles();
+    const wrapped = wrappedFiles.find(f => f.getName() === targetName);
+    if (!wrapped) return;
+    const internalFile = wrapped.file ?? wrapped;
+
+    // Only switch if the IDE is not already showing this file.
+    const currentlyActive = ide.fileExplorer.treeview
+      ?.getCurrentlySelectedNodes?.()
+      ?.[0]?.externalObject;
+    if (currentlyActive && currentlyActive.name === targetName) return;
+
+    ide.fileExplorer.selectFile(internalFile, false);
   }
 }

--- a/custom-generator-codelab/src/utils/IdeBridge.js
+++ b/custom-generator-codelab/src/utils/IdeBridge.js
@@ -177,7 +177,7 @@ export class IdeBridge {
     const currentlyActive = ide.fileExplorer.treeview
       ?.getCurrentlySelectedNodes?.()
       ?.[0]?.externalObject;
-    if (currentlyActive && currentlyActive.name === targetName) return;
+    if (currentlyActive?.name === targetName) return;
 
     ide.fileExplorer.selectFile(internalFile, false);
   }


### PR DESCRIPTION
Improve the IDE's functionality by ensuring it switches back to the last active Java file when displaying a Markdown file. Update file import functions to handle both Java and Markdown files, and adjust file counting in clone and pull operations to include Markdown files. Refactor file deletion and addition logs for better generalization across file types. Additionally, hide the code reset button for a cleaner interface.

Closes #49