### PR TITLE
Load first Java file's Blockly workspace in Markdown view

### DIFF
--- a/custom-generator-codelab/src/index.js
+++ b/custom-generator-codelab/src/index.js
@@ -367,6 +367,16 @@ async function handleClone() {
       const node = ide?.fileExplorer?.treeview?.nodes?.find(n => n.externalObject === internalFile);
       if (node) ide.fileExplorer.treeview.selectNodeAndSetFocus(node, false);
       ide?.fileExplorer?.selectFile?.(internalFile);
+
+      // Load the first Java file's Blockly workspace without switching the IDE
+      // view away from the markdown file.
+      const firstJavaFile = ideFiles.find(f => f.getName().toLowerCase().endsWith('.java'));
+      if (firstJavaFile) {
+        IdeBridge.selected_file_name = firstJavaFile.getName();
+        IdeBridge.last_java_file_name = firstJavaFile.getName();
+        IdeBridge.syncClassNameFromIDE();
+        load(ws);
+      }
     } else if (!IdeBridge.selected_file_name) {
       if (ideFiles.length > 0) {
         IdeBridge.fileSelected(ideFiles[0].getName());


### PR DESCRIPTION
Enable loading the first Java file's Blockly workspace without switching from the Markdown view, enhancing user experience and workflow efficiency.

Closes #52