### PR TITLE
Avoid accidental overwrite of Java changes via Blockly

### DIFF
--- a/custom-generator-codelab/src/index.html
+++ b/custom-generator-codelab/src/index.html
@@ -190,6 +190,29 @@
                 </div>
                 <div class="pane-content">
                     <div id="blocklyDiv" class="content-container content-container--constrained"></div>
+                    <!-- Overlay shown when the user has manually edited the Java code.
+                         Clicking it triggers a confirmation dialog before Blockly can
+                         overwrite the manual edits. -->
+                    <div id="blocklyModifiedOverlay"
+                         class="blockly-modified-overlay"
+                         role="button" tabindex="0"
+                         aria-label="Manuelle Java-Änderungen aktiv – klicken, um Blockly wieder zu verwenden">
+                        <div class="blockly-modified-overlay__card">
+                            <svg class="blockly-modified-overlay__icon"
+                                 width="32" height="32" viewBox="0 0 24 24" fill="none"
+                                 stroke="currentColor" stroke-width="1.8"
+                                 stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                                <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/>
+                                <line x1="12" y1="9"  x2="12"   y2="13"/>
+                                <line x1="12" y1="17" x2="12.01" y2="17"/>
+                            </svg>
+                            <p class="blockly-modified-overlay__title">Manuelle Java-Änderungen aktiv</p>
+                            <p class="blockly-modified-overlay__hint">
+                                Blockly-Änderungen würden den manuell bearbeiteten Code überschreiben.<br>
+                                <strong>Klicken zum Fortfahren</strong>
+                            </p>
+                        </div>
+                    </div>
                 </div>
             </div>
             <div id="divider" class="split-divider"></div>

--- a/custom-generator-codelab/src/index.js
+++ b/custom-generator-codelab/src/index.js
@@ -26,6 +26,7 @@ import { GitService } from './utils/GitService';
 import { GitDialog } from './utils/GitDialog';
 import { ToolboxConfigManager } from './utils/ToolboxConfigManager';
 import { WorkspaceManager, FULL_ACTIVE_CONFIG } from './utils/WorkspaceManager';
+import { BlocklyOverlayManager } from './utils/BlocklyOverlayManager';
 
 // Module-level state
 export let ws;
@@ -57,6 +58,17 @@ function init() {
   // Load the initial state from storage and run the code.
   load(ws);
   //onBlocksChange();
+
+  // Initialise the overlay manager that guards Blockly when Java was manually edited.
+  BlocklyOverlayManager.init({
+    getIDECode:     () => IdeBridge.getCurrentIDECode(),
+    getClassName:   () => IdeBridge.selected_file_name.replace('.java', ''),
+    onBlocksChange: () => onBlocksChange(),
+  });
+
+  // Show overlay immediately if the initially loaded class is already flagged.
+  const initialClassName = IdeBridge.selected_file_name.replace('.java', '');
+  BlocklyOverlayManager.updateForClass(initialClassName);
 
   setupListeners(ws);
 }
@@ -108,6 +120,8 @@ function setupListeners(workspace) {
   // Intercept assignments to globalThis.online_ide_access.
   // When the embedded IDE initialises it sets window.online_ide_access;
   // register IdeBridge callbacks at that moment.
+  let _javaModifiedPollId = null;
+
   Object.defineProperty(globalThis, 'online_ide_access', {
     set: function(value) {
       this._online_ide_access = value;
@@ -117,6 +131,20 @@ function setupListeners(workspace) {
         ideAccess.onFileDeleted( (name)       => IdeBridge.fileDeleted(name));
         ideAccess.onFileCreated( (name)       => IdeBridge.fileCreated(name));
         ideAccess.onFileSelected((name)       => IdeBridge.fileSelected(name));
+
+        // ── Java-modified detection polling ───────────────────────────
+        // Poll every 350 ms to compare the IDE's current code against the
+        // last Blockly-generated baseline.  As soon as they diverge (= the
+        // user typed something in the Java editor) we set the flag and show
+        // the overlay without waiting for the next Blockly event.
+        if (_javaModifiedPollId) clearInterval(_javaModifiedPollId);
+        _javaModifiedPollId = setInterval(() => {
+          const className = IdeBridge.selected_file_name.replace('.java', '');
+          if (!className) return;
+          // Already flagged — overlay is visible, nothing more to do.
+          if (LocalStorageManager.isJavaModified(className)) return;
+          BlocklyOverlayManager.detectAndMarkIfModified(className);
+        }, 350);
       }
 
       // ── Lift the IDE's bottom panel into B2J's managed section ────────────
@@ -163,6 +191,15 @@ function setupListeners(workspace) {
       workspace.isDragging()) {
       return;
     }
+
+    // Before regenerating, check whether the user manually edited the Java code
+    // since the last Blockly push.  If so, lock Blockly via the overlay and
+    // skip the push — preserving the manual edits.
+    const className = IdeBridge.selected_file_name.replace('.java', '');
+    if (BlocklyOverlayManager.detectAndMarkIfModified(className)) {
+      return;
+    }
+
     onBlocksChange();
   });
 

--- a/custom-generator-codelab/src/index.js
+++ b/custom-generator-codelab/src/index.js
@@ -191,15 +191,6 @@ function setupListeners(workspace) {
       workspace.isDragging()) {
       return;
     }
-
-    // Before regenerating, check whether the user manually edited the Java code
-    // since the last Blockly push.  If so, lock Blockly via the overlay and
-    // skip the push — preserving the manual edits.
-    const className = IdeBridge.selected_file_name.replace('.java', '');
-    if (BlocklyOverlayManager.detectAndMarkIfModified(className)) {
-      return;
-    }
-
     onBlocksChange();
   });
 
@@ -250,6 +241,15 @@ export function onBlocksChange() {
   IdeBridge.ensureJavaFileActive();
 
   IdeBridge.syncClassNameFromIDE();
+
+  // Do not overwrite manually edited Java code.  This guard covers every call
+  // site: Blockly events, post-import, post-clone/pull, etc.
+  const className = IdeBridge.selected_file_name.replace('.java', '');
+  if (className && LocalStorageManager.isJavaModified(className)) {
+    BlocklyOverlayManager.show();
+    return;
+  }
+
   LocalStorageManager.clearConstructors(getClassName());
 
   const rawCode = generateCode();

--- a/custom-generator-codelab/src/styles/ide.css
+++ b/custom-generator-codelab/src/styles/ide.css
@@ -147,3 +147,76 @@ g.blocklyWorkspace {
 .b2j-btn-static-attr > .blocklyFlyoutButtonBackground:hover {
     fill: #3f3f9e;
 }
+
+/* ── Blockly "java-modified" overlay ─────────────────────────────────────── */
+
+/*
+ * The left pane's .pane-content must be a positioned container so the overlay
+ * can be absolute-positioned inside it.
+ */
+#leftPane > .pane-content {
+    position: relative;
+}
+
+/*
+ * The overlay itself.  Hidden by default; shown by adding --visible.
+ * It sits on top of #blocklyDiv and intercepts all pointer events so the user
+ * can't accidentally drag blocks while java-modified is active.
+ */
+.blockly-modified-overlay {
+    display: none;          /* hidden by default */
+    position: absolute;
+    inset: 0;
+    z-index: 200;           /* above Blockly's own z-index but below modal dialogs */
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.60);
+    cursor: pointer;
+    user-select: none;
+    /* Smooth fade-in */
+    animation: none;
+}
+
+.blockly-modified-overlay--visible {
+    display: flex;
+}
+
+/* Central card shown inside the overlay */
+.blockly-modified-overlay__card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+    padding: 28px 36px;
+    max-width: 340px;
+    text-align: center;
+    background: var(--secondary-bg, #1e293b);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 14px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.55);
+    color: var(--text-primary, #f8fafc);
+    pointer-events: none; /* card itself doesn't swallow the click – overlay does */
+}
+
+.blockly-modified-overlay__icon {
+    color: #f59e0b;   /* amber warning colour */
+    flex-shrink: 0;
+}
+
+.blockly-modified-overlay__title {
+    font-size: 15px;
+    font-weight: 700;
+    margin: 0;
+    letter-spacing: 0.02em;
+}
+
+.blockly-modified-overlay__hint {
+    font-size: 12.5px;
+    color: var(--text-secondary, #94a3b8);
+    margin: 0;
+    line-height: 1.55;
+}
+
+.blockly-modified-overlay__hint strong {
+    color: var(--text-primary, #f8fafc);
+}

--- a/custom-generator-codelab/src/utils/BlocklyOverlayManager.js
+++ b/custom-generator-codelab/src/utils/BlocklyOverlayManager.js
@@ -32,6 +32,14 @@ export class BlocklyOverlayManager {
     static _dialogOpen = false;
 
     /**
+     * Timestamp (Date.now()) of the last Blockly → IDE push.
+     * The poll skips detection for PUSH_GRACE_MS after each push to avoid
+     * false positives while Monaco is asynchronously applying the new text.
+     */
+    static _lastPushAt = 0;
+    static PUSH_GRACE_MS = 1500;
+
+    /**
      * Callback that returns the current IDE Java code, or null if unavailable.
      * @type {(() => string|null)|null}
      */
@@ -99,6 +107,15 @@ export class BlocklyOverlayManager {
     }
 
     /**
+     * Called by IdeBridge.pushCodeToIDE() immediately after every Blockly push.
+     * Starts the grace period during which the poll skips detection so Monaco
+     * has time to settle before we compare texts.
+     */
+    static notifyPushed() {
+        this._lastPushAt = Date.now();
+    }
+
+    /**
      * Checks whether the IDE currently contains code that differs from what
      * Blockly last generated.  If so, persists the java-modified flag and
      * shows the overlay.
@@ -117,6 +134,10 @@ export class BlocklyOverlayManager {
             this.show();
             return true;
         }
+
+        // Skip detection during the grace period after a Blockly push so
+        // Monaco has time to update getText() before we compare.
+        if (Date.now() - this._lastPushAt < this.PUSH_GRACE_MS) return false;
 
         // No cache yet → Blockly has never pushed code for this class.
         const lastGenerated = LocalStorageManager.loadLastGeneratedCode(className);

--- a/custom-generator-codelab/src/utils/BlocklyOverlayManager.js
+++ b/custom-generator-codelab/src/utils/BlocklyOverlayManager.js
@@ -276,10 +276,18 @@ export class BlocklyOverlayManager {
             backdrop.appendChild(card);
             document.body.appendChild(backdrop);
 
-            // Keyboard: Escape → cancel, Enter → confirm
+            // Keyboard: Escape → cancel (always), Enter → confirm only when the
+            // confirm button itself has focus to avoid accidental overwrites.
             const onKey = (e) => {
-                if (e.key === 'Escape') { e.preventDefault(); close(false); }
-                if (e.key === 'Enter')  { e.preventDefault(); close(true);  }
+                if (e.key === 'Escape') {
+                    e.preventDefault();
+                    close(false);
+                    return;
+                }
+                if (e.key === 'Enter' && document.activeElement === confirmBtn) {
+                    e.preventDefault();
+                    close(true);
+                }
             };
             document.addEventListener('keydown', onKey);
 

--- a/custom-generator-codelab/src/utils/BlocklyOverlayManager.js
+++ b/custom-generator-codelab/src/utils/BlocklyOverlayManager.js
@@ -1,0 +1,270 @@
+/**
+ * BlocklyOverlayManager
+ *
+ * Manages the translucent "Java code modified" overlay that appears over the
+ * Blockly workspace whenever the user has manually edited the generated Java
+ * code in the IDE editor.
+ *
+ * Behaviour
+ * ─────────
+ * • When Blockly pushes code to the IDE, the exact pushed string is stored in
+ *   localStorage as the "last generated code" for that class.
+ * • Whenever a Blockly change event fires, detectAndMarkIfModified() compares
+ *   the current IDE content to the stored string.  If they differ, the class
+ *   is flagged in localStorage (survives reloads) and the overlay is shown.
+ * • The overlay intercepts all pointer input over the Blockly canvas.  When
+ *   the user clicks it, a confirmation dialog appears:
+ *     – Cancel → overlay stays; Java changes are preserved.
+ *     – Confirm → flag and cache are cleared, overlay hides, and the current
+ *       Blockly workspace is re-pushed to the IDE (overwriting manual edits).
+ * • On page reload or file switch, updateForClass() reads the flag from
+ *   localStorage and immediately shows the overlay when appropriate.
+ */
+
+import LocalStorageManager from './LocalStorageManager.js';
+
+export class BlocklyOverlayManager {
+
+    /** @type {HTMLElement|null} */
+    static _overlayEl = null;
+
+    /** @type {boolean} — prevents stacking multiple dialogs */
+    static _dialogOpen = false;
+
+    /**
+     * Callback that returns the current IDE Java code, or null if unavailable.
+     * @type {(() => string|null)|null}
+     */
+    static _getIDECodeFn = null;
+
+    /**
+     * Callback that returns the current class name (without .java extension).
+     * @type {(() => string)|null}
+     */
+    static _getClassNameFn = null;
+
+    /**
+     * Callback to trigger Blockly → IDE code regeneration.
+     * @type {(() => void)|null}
+     */
+    static _onBlocksChangeFn = null;
+
+    // ── Initialisation ────────────────────────────────────────────────────────
+
+    /**
+     * One-time setup. Must be called after the DOM is ready.
+     *
+     * @param {object} callbacks
+     * @param {() => string|null} callbacks.getIDECode   – returns current IDE code
+     * @param {() => string}      callbacks.getClassName – returns active class name
+     * @param {() => void}        callbacks.onBlocksChange – regenerates + pushes code
+     */
+    static init({ getIDECode, getClassName, onBlocksChange }) {
+        this._getIDECodeFn     = getIDECode;
+        this._getClassNameFn   = getClassName;
+        this._onBlocksChangeFn = onBlocksChange;
+
+        this._overlayEl = document.getElementById('blocklyModifiedOverlay');
+        if (!this._overlayEl) {
+            console.warn('BlocklyOverlayManager: #blocklyModifiedOverlay not found.');
+            return;
+        }
+
+        this._overlayEl.addEventListener('click',   () => this._handleOverlayClick());
+        this._overlayEl.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                this._handleOverlayClick();
+            }
+        });
+    }
+
+    // ── Public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Reads the persisted java-modified flag for the given class and shows or
+     * hides the overlay accordingly.  Call this whenever the active class changes
+     * (file selected, page loaded).
+     *
+     * @param {string} className – class name without .java extension
+     */
+    static updateForClass(className) {
+        if (!className) { this.hide(); return; }
+
+        if (LocalStorageManager.isJavaModified(className)) {
+            this.show();
+        } else {
+            this.hide();
+        }
+    }
+
+    /**
+     * Checks whether the IDE currently contains code that differs from what
+     * Blockly last generated.  If so, persists the java-modified flag and
+     * shows the overlay.
+     *
+     * Returns `true` when the class is (or just became) java-modified so the
+     * caller knows to abort the Blockly→IDE push.
+     *
+     * @param {string} className – class name without .java extension
+     * @returns {boolean}
+     */
+    static detectAndMarkIfModified(className) {
+        if (!className) return false;
+
+        // Already flagged — just make sure the overlay is visible.
+        if (LocalStorageManager.isJavaModified(className)) {
+            this.show();
+            return true;
+        }
+
+        // No cache yet → Blockly has never pushed code for this class.
+        const lastGenerated = LocalStorageManager.loadLastGeneratedCode(className);
+        if (lastGenerated === null) return false;
+
+        const currentCode = this._getIDECodeFn?.();
+        if (currentCode === null || currentCode === undefined) return false;
+
+        if (currentCode.trim() !== lastGenerated.trim()) {
+            // User has manually edited the IDE – flag and lock.
+            LocalStorageManager.setJavaModified(className, true);
+            this.show();
+            return true;
+        }
+
+        return false;
+    }
+
+    /** Show the overlay (locks Blockly interaction). */
+    static show() {
+        this._overlayEl?.classList.add('blockly-modified-overlay--visible');
+    }
+
+    /** Hide the overlay (unlocks Blockly interaction). */
+    static hide() {
+        this._overlayEl?.classList.remove('blockly-modified-overlay--visible');
+    }
+
+    /** @returns {boolean} whether the overlay is currently visible */
+    static isVisible() {
+        return this._overlayEl?.classList.contains('blockly-modified-overlay--visible') ?? false;
+    }
+
+    // ── Internal ──────────────────────────────────────────────────────────────
+
+    /** Invoked when the user clicks the overlay.  Shows the confirmation dialog. */
+    static async _handleOverlayClick() {
+        if (this._dialogOpen) return;
+        this._dialogOpen = true;
+
+        const confirmed = await this._showConfirmDialog();
+        this._dialogOpen = false;
+
+        if (confirmed) {
+            const className = this._getClassNameFn?.() ?? '';
+            // Clear the persisted flag. The generated-code cache will be refreshed
+            // synchronously by onBlocksChange() below before any other JS can run.
+            LocalStorageManager.setJavaModified(className, false);
+            // Hide overlay before regenerating so the workspace is visible immediately.
+            this.hide();
+            // Regenerate code from the current Blockly workspace and push to IDE.
+            this._onBlocksChangeFn?.();
+        }
+        // else: do nothing — overlay stays, Java edits are preserved.
+    }
+
+    /**
+     * Renders and returns a promise-based confirmation dialog that warns the user
+     * about losing their manual Java edits.
+     *
+     * The dialog reuses the `.git-modal-*` CSS classes so it looks consistent
+     * with all other B2J dialogs.
+     *
+     * @returns {Promise<boolean>} true → user confirmed overwrite; false → cancelled
+     */
+    static _showConfirmDialog() {
+        return new Promise((resolve) => {
+
+            // ── Backdrop ──────────────────────────────────────────────────────
+            const backdrop = document.createElement('div');
+            backdrop.className = 'git-modal-overlay';
+
+            // ── Card ──────────────────────────────────────────────────────────
+            const card = document.createElement('div');
+            card.className = 'git-modal-card';
+
+            // ── Title ─────────────────────────────────────────────────────────
+            const titleEl = document.createElement('h3');
+            titleEl.className = 'git-modal-title';
+            titleEl.textContent = 'Manuelle Java-Änderungen verwerfen?';
+            card.appendChild(titleEl);
+
+            // ── Warning icon row ──────────────────────────────────────────────
+            const iconRow = document.createElement('div');
+            iconRow.style.cssText = 'display:flex;align-items:center;gap:10px;margin:4px 0 8px;';
+            iconRow.innerHTML =
+                `<svg width="22" height="22" viewBox="0 0 24 24" fill="none"
+                      stroke="#f59e0b" stroke-width="2" stroke-linecap="round"
+                      stroke-linejoin="round" aria-hidden="true" style="flex-shrink:0">
+                   <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/>
+                   <line x1="12" y1="9" x2="12" y2="13"/>
+                   <line x1="12" y1="17" x2="12.01" y2="17"/>
+                 </svg>`;
+            card.appendChild(iconRow);
+
+            // ── Body ──────────────────────────────────────────────────────────
+            const bodyEl = document.createElement('p');
+            bodyEl.className = 'git-modal-body';
+            bodyEl.textContent =
+                'Du hast den Java-Code manuell bearbeitet. Wenn du jetzt in Blockly ' +
+                'eine Änderung bestätigst, werden deine Java-Änderungen unwiderruflich ' +
+                'durch den generierten Code überschrieben.';
+            card.appendChild(bodyEl);
+
+            const bodyEl2 = document.createElement('p');
+            bodyEl2.className = 'git-modal-body';
+            bodyEl2.style.marginTop = '6px';
+            bodyEl2.textContent = 'Möchtest du die manuellen Java-Änderungen verwerfen und Blockly wieder verwenden?';
+            card.appendChild(bodyEl2);
+
+            // ── Buttons ───────────────────────────────────────────────────────
+            const btnRow = document.createElement('div');
+            btnRow.className = 'git-modal-buttons';
+
+            const close = (val) => {
+                backdrop.remove();
+                document.removeEventListener('keydown', onKey);
+                resolve(val);
+            };
+
+            // Cancel — keep Java edits
+            const cancelBtn = document.createElement('button');
+            cancelBtn.className = 'git-modal-btn git-modal-btn--cancel';
+            cancelBtn.textContent = 'Abbrechen (Java behalten)';
+            cancelBtn.addEventListener('click', () => close(false));
+            btnRow.appendChild(cancelBtn);
+
+            // Confirm — overwrite with Blockly
+            const confirmBtn = document.createElement('button');
+            confirmBtn.className = 'git-modal-btn git-modal-btn--submit git-modal-btn--danger';
+            confirmBtn.textContent = 'Java-Änderungen verwerfen';
+            confirmBtn.addEventListener('click', () => close(true));
+            btnRow.appendChild(confirmBtn);
+
+            card.appendChild(btnRow);
+            backdrop.appendChild(card);
+            document.body.appendChild(backdrop);
+
+            // Keyboard: Escape → cancel, Enter → confirm
+            const onKey = (e) => {
+                if (e.key === 'Escape') { e.preventDefault(); close(false); }
+                if (e.key === 'Enter')  { e.preventDefault(); close(true);  }
+            };
+            document.addEventListener('keydown', onKey);
+
+            // Focus the safe (cancel) button by default so accidental Enter doesn't
+            // immediately destroy edits.
+            setTimeout(() => cancelBtn.focus(), 0);
+        });
+    }
+}

--- a/custom-generator-codelab/src/utils/GitService.js
+++ b/custom-generator-codelab/src/utils/GitService.js
@@ -274,60 +274,97 @@ export class GitService {
   }
 
   /**
-   * Scans `lines` with brace-depth tracking and returns the index of the
-   * first line that opens the outermost class/interface/enum body and the
-   * index of the last line that closes it.
+   * Scans `content` at character level, correctly skipping string literals
+   * and comments, and returns the character positions of the outermost
+   * class-body delimiters.
    *
-   * @param {string[]} lines
-   * @returns {{ firstOpenLineIdx: number, lastCloseLineIdx: number }}
-   *   Both indices are -1 when no class body is found.
+   * This is more precise than the old line-level scanner because it correctly
+   * handles cases where top-level code sits on the *same line* as `{` or `}`.
+   *
+   * @param {string} content
+   * @returns {{ firstOpenPos: number, lastClosePos: number }}
+   *   Both values are -1 when no class body is found.
    */
-  static _findClassBoundaries(lines) {
+  static _findClassBoundariesPos(content) {
     let depth = 0;
-    let firstOpenLineIdx = -1;
-    let lastCloseLineIdx = -1;
+    let firstOpenPos = -1;
+    let lastClosePos = -1;
+    let i = 0;
 
-    for (let i = 0; i < lines.length; i++) {
-      for (const char of lines[i]) {
-        if (char === '{') {
-          if (depth === 0 && firstOpenLineIdx === -1) firstOpenLineIdx = i;
-          depth++;
-        } else if (char === '}') {
-          depth--;
-          if (depth === 0) lastCloseLineIdx = i;
-        }
+    while (i < content.length) {
+      // Skip line comments
+      if (content[i] === '/' && content[i + 1] === '/') {
+        const nl = content.indexOf('\n', i);
+        i = nl === -1 ? content.length : nl + 1;
+        continue;
       }
+      // Skip block comments
+      if (content[i] === '/' && content[i + 1] === '*') {
+        const end = content.indexOf('*/', i + 2);
+        i = end === -1 ? content.length : end + 2;
+        continue;
+      }
+      // Skip string / char literals
+      if (content[i] === '"' || content[i] === "'") {
+        const q = content[i++];
+        while (i < content.length && content[i] !== q) {
+          if (content[i] === '\\') i++;
+          i++;
+        }
+        i++;
+        continue;
+      }
+
+      if (content[i] === '{') {
+        if (depth === 0) firstOpenPos = i;
+        depth++;
+      } else if (content[i] === '}') {
+        depth--;
+        if (depth === 0) lastClosePos = i;
+      }
+      i++;
     }
 
-    return { firstOpenLineIdx, lastCloseLineIdx };
+    return { firstOpenPos, lastClosePos };
   }
 
   /**
    * Detects top-level Java code: executable statements that appear either
-   * before or after the outermost class/interface/enum body.
+   * before or after the outermost class/interface/enum body, including code
+   * that shares a line with the opening `{` or closing `}`.
    *
    * @param {string} javaContent
    * @returns {string|null} trimmed top-level code, or null if none found
    */
   static detectTopLevelCode(javaContent) {
-    const lines = javaContent.split('\n');
-    const { firstOpenLineIdx, lastCloseLineIdx } = this._findClassBoundaries(lines);
+    const { firstOpenPos, lastClosePos } = this._findClassBoundariesPos(javaContent);
 
     const parts = [];
 
-    // Code before the first class/interface/enum definition
-    if (firstOpenLineIdx > 0) {
-      const preCode = lines
-        .slice(0, firstOpenLineIdx)
-        .filter(l => !this._isHeaderLine(l))
-        .join('\n')
-        .trim();
-      if (preCode) parts.push(preCode);
+    // Code before the class/interface/enum keyword (not the opening brace),
+    // so that the declaration itself is not included in the preview.
+    if (firstOpenPos > 0) {
+      const lineStart = javaContent.lastIndexOf('\n', firstOpenPos - 1) + 1;
+      const linePre = javaContent.substring(lineStart, firstOpenPos);
+      const classMatch = linePre.match(
+        /((?:(?:public|protected|private|abstract|final|strictfp)\s+)*)(?:class|interface|enum)\s/
+      );
+      const classStartInLine = classMatch ? linePre.indexOf(classMatch[0]) : linePre.length;
+      const classStartPos = lineStart + classStartInLine;
+
+      if (classStartPos > 0) {
+        const preContent = javaContent.substring(0, classStartPos);
+        const preCode = preContent.split('\n')
+          .filter(l => !this._isHeaderLine(l))
+          .join('\n')
+          .trim();
+        if (preCode) parts.push(preCode);
+      }
     }
 
-    // Code after the last class closing brace
-    if (lastCloseLineIdx !== -1) {
-      const postCode = lines.slice(lastCloseLineIdx + 1).join('\n').trim();
+    // Code after the last closing brace (may include content on the same line)
+    if (lastClosePos !== -1 && lastClosePos < javaContent.length - 1) {
+      const postCode = javaContent.substring(lastClosePos + 1).trim();
       if (postCode) parts.push(postCode);
     }
 
@@ -336,29 +373,67 @@ export class GitService {
 
   /**
    * Returns a copy of the Java content with all top-level executable code
-   * removed (both before and after the outermost class body).
-   * Preamble lines (import, package, blank, comments) are preserved.
+   * commented out using block comments, both before and after the outermost
+   * class body.  Code that shares a line with the opening '{' or closing '}'
+   * is commented out inline so no newlines are introduced.
+   * Preamble lines (import, package, blank, existing comments) are preserved.
    *
    * @param {string} javaContent
    * @returns {string}
    */
   static stripTopLevelCode(javaContent) {
-    const lines = javaContent.split('\n');
-    const { firstOpenLineIdx, lastCloseLineIdx } = this._findClassBoundaries(lines);
+    const { firstOpenPos, lastClosePos } = this._findClassBoundariesPos(javaContent);
 
-    if (firstOpenLineIdx === -1 && lastCloseLineIdx === -1) return javaContent;
+    if (firstOpenPos === -1 && lastClosePos === -1) return javaContent;
 
-    const closeLine = lastCloseLineIdx !== -1 ? lastCloseLineIdx : lines.length - 1;
+    let result = javaContent;
 
-    if (firstOpenLineIdx <= 0) {
-      // No pre-class lines at all; just drop everything after the closing brace.
-      return lines.slice(0, closeLine + 1).join('\n');
+    // ── Post-class code (after lastClosePos) ─────────────────────────────
+    // Must be done first so that firstOpenPos stays valid (it comes earlier).
+    if (lastClosePos !== -1 && lastClosePos < result.length - 1) {
+      const postContent = result.substring(lastClosePos + 1);
+      if (postContent.trim()) {
+        result =
+          result.substring(0, lastClosePos + 1) +
+          ' /*' + postContent.trim() + '*/';
+      }
     }
 
-    // Keep only header lines (import/package/blank/comments) from before the class.
-    const preamble = lines.slice(0, firstOpenLineIdx).filter(l => this._isHeaderLine(l));
-    const classBody = lines.slice(firstOpenLineIdx, closeLine + 1);
-    return [...preamble, ...classBody].join('\n');
+    // ── Pre-class code (before firstOpenPos) ─────────────────────────────
+    if (firstOpenPos > 0) {
+      // Find the start of the line that contains the opening '{'.
+      const lineStart = result.lastIndexOf('\n', firstOpenPos - 1) + 1;
+      // The portion of that line sitting before '{'.
+      const linePre = result.substring(lineStart, firstOpenPos);
+
+      // Locate the beginning of the class/interface/enum declaration within
+      // that line so we know exactly what to comment out.
+      const classMatch = linePre.match(
+        /((?:(?:public|protected|private|abstract|final|strictfp)\s+)*)(?:class|interface|enum)\s/
+      );
+      const classStartInLine = classMatch ? linePre.indexOf(classMatch[0]) : 0;
+      const classStartPos = lineStart + classStartInLine;
+
+      // Split the text before the class keyword into lines.
+      const preContent = result.substring(0, classStartPos);
+      const preLines = preContent.split('\n');
+
+      // All fully-preceding lines: use `// ` for non-header lines.
+      const commentOutLine = l => this._isHeaderLine(l) ? l : '// ' + l;
+      const fullPrecedingLines = preLines.slice(0, -1).map(commentOutLine);
+
+      // The partial line sharing the row with the class declaration:
+      // wrap in `/* … */` inline (only if it contains non-whitespace).
+      const partialLine = preLines[preLines.length - 1];
+      const commentedPartialLine =
+        partialLine.trim() ? '/*' + partialLine.trimEnd() + '*/ ' : partialLine;
+
+      result =
+        [...fullPrecedingLines, commentedPartialLine].join('\n') +
+        result.substring(classStartPos);
+    }
+
+    return result;
   }
 
   /**

--- a/custom-generator-codelab/src/utils/GitService.js
+++ b/custom-generator-codelab/src/utils/GitService.js
@@ -402,6 +402,7 @@ export class GitService {
     // ── Export current workspace into the virtual filesystem ──────────────
     await this._exportJsonFiles(fs);
     await this._exportJavaFiles(fs, { stripTopLevelCode });
+    await this._exportMetadataFile(fs);
 
     // ── Stage all changed / new / deleted files ──────────────────────────
     const matrix = await git.statusMatrix({ fs, dir: this.REPO_DIR });
@@ -435,6 +436,23 @@ export class GitService {
       headers: this._authHeaders(config.username, config.password),
       onAuth: () => ({ username: config.username, password: config.password }),
     });
+  }
+
+  // ── Metadata file helper ──────────────────────────────────────────────────
+
+  /**
+   * Writes `b2j-metadata.json` at the repository root.
+   * Records which classes have been manually edited so the flag survives a
+   * round-trip through commit → clone/pull.
+   * @param {LightningFS} fs
+   */
+  static async _exportMetadataFile(fs) {
+    const modifiedClasses = LocalStorageManager.getAllJavaModifiedClassNames();
+    const content = JSON.stringify({ javaModified: modifiedClasses }, null, 2);
+    await fs.promises.writeFile(
+      `${this.REPO_DIR}/b2j-metadata.json`,
+      new TextEncoder().encode(content),
+    );
   }
 
   // ── File I/O helpers ─────────────────────────────────────────────────────
@@ -498,6 +516,22 @@ export class GitService {
       result.toolboxConfig = JSON.parse(new TextDecoder().decode(raw));
     } catch {
       /* No blockly-config.json present – that is perfectly fine. */
+    }
+
+    // Restore java-modified flags from the repo metadata file.
+    // If the file is absent (legacy repo or flags were cleared and pushed),
+    // treat it as "no classes modified" and wipe any stale local flags.
+    try {
+      const raw = await fs.promises.readFile(`${this.REPO_DIR}/b2j-metadata.json`);
+      const meta = JSON.parse(new TextDecoder().decode(raw));
+      if (Array.isArray(meta?.javaModified)) {
+        LocalStorageManager.restoreJavaModifiedClassNames(meta.javaModified);
+      } else {
+        LocalStorageManager.restoreJavaModifiedClassNames([]);
+      }
+    } catch {
+      // File absent → clear all stale flags.
+      LocalStorageManager.restoreJavaModifiedClassNames([]);
     }
 
     for (const entry of entries) {

--- a/custom-generator-codelab/src/utils/IdeBridge.js
+++ b/custom-generator-codelab/src/utils/IdeBridge.js
@@ -170,8 +170,15 @@ export class IdeBridge {
     // If the class was manually edited, show the overlay and do NOT push
     // Blockly-generated code (which would overwrite the user's edits).
     const className = fileName.replace('.java', '');
+    // First, perform an immediate check to detect recent manual edits
+    // that may not yet have been picked up by the polling mechanism.
+    const wasJustDetectedAsModified =
+      BlocklyOverlayManager.detectAndMarkIfModified
+        ? BlocklyOverlayManager.detectAndMarkIfModified(className) === true
+        : false;
+
     BlocklyOverlayManager.updateForClass(className);
-    if (!LocalStorageManager.isJavaModified(className)) {
+    if (!wasJustDetectedAsModified && !LocalStorageManager.isJavaModified(className)) {
       onBlocksChange();
     }
   }

--- a/custom-generator-codelab/src/utils/IdeBridge.js
+++ b/custom-generator-codelab/src/utils/IdeBridge.js
@@ -57,6 +57,9 @@ export class IdeBridge {
       LocalStorageManager.saveLastGeneratedCode(className, modCode);
       LocalStorageManager.setJavaModified(className, false);
       BlocklyOverlayManager.hide();
+      // Start the grace period so the poll doesn't fire a false positive
+      // while Monaco asynchronously applies the new text.
+      BlocklyOverlayManager.notifyPushed();
     }
   }
 

--- a/custom-generator-codelab/src/utils/IdeBridge.js
+++ b/custom-generator-codelab/src/utils/IdeBridge.js
@@ -3,6 +3,7 @@ import { setClassName } from "../generators/javascript/javascript_generator";
 import LocalStorageManager from "./LocalStorageManager.js";
 import { load } from "../serialization.js";
 import { onBlocksChange } from '../index.js';
+import { BlocklyOverlayManager } from './BlocklyOverlayManager.js';
 
 
 export class IdeBridge {
@@ -47,6 +48,33 @@ export class IdeBridge {
         file.setText(modCode);
       }
     }
+
+    // Persist what Blockly generated so detectAndMarkIfModified() can later
+    // compare it to the IDE content and detect manual user edits.
+    // Also clear the java-modified flag and overlay: Blockly is now in sync.
+    const className = selectedFileName.replace('.java', '');
+    if (className) {
+      LocalStorageManager.saveLastGeneratedCode(className, modCode);
+      LocalStorageManager.setJavaModified(className, false);
+      BlocklyOverlayManager.hide();
+    }
+  }
+
+  /**
+   * Returns the current text content of the selected file as shown in the IDE
+   * editor, or null if the IDE is not ready / no file is selected.
+   * Used by BlocklyOverlayManager to detect manual edits.
+   * @returns {string|null}
+   */
+  static getCurrentIDECode() {
+    if (!globalThis.online_ide_access) return null;
+    const ideAccess = globalThis.online_ide_access.getIDE?.('Java');
+    if (!ideAccess) return null;
+    const files = ideAccess.getFiles();
+    const fileName = this.selected_file_name;
+    const file = files.find(f => f.getName() === fileName);
+    if (!file) return null;
+    return file.getText?.() ?? file.text ?? null;
   }
 
   /**
@@ -137,7 +165,15 @@ export class IdeBridge {
 
     // Sync the class name used by the code generator.
     this.syncClassNameFromIDE();
-    onBlocksChange();
+
+    // Update the java-modified overlay for the newly selected class.
+    // If the class was manually edited, show the overlay and do NOT push
+    // Blockly-generated code (which would overwrite the user's edits).
+    const className = fileName.replace('.java', '');
+    BlocklyOverlayManager.updateForClass(className);
+    if (!LocalStorageManager.isJavaModified(className)) {
+      onBlocksChange();
+    }
   }
 
   /**

--- a/custom-generator-codelab/src/utils/LocalStorageManager.js
+++ b/custom-generator-codelab/src/utils/LocalStorageManager.js
@@ -147,6 +147,71 @@ class LocalStorageManager {
         globalThis.localStorage?.setItem(key, JSON.stringify(data));
     }
 
+    // ── Java-modified bulk helpers ────────────────────────────────────────────
+
+    /**
+     * Removes all java-modified flags and last-generated-code cache entries
+     * from localStorage.  Call this when the entire workspace is reset.
+     */
+    static clearAllJavaModifiedData() {
+        const ls = globalThis.localStorage;
+        if (!ls) return;
+        const toRemove = [];
+        for (let i = 0; i < ls.length; i++) {
+            const key = ls.key(i);
+            if (key?.startsWith(this.JAVA_MODIFIED_KEY_PREFIX) ||
+                key?.startsWith(this.JAVA_GENERATED_KEY_PREFIX)) {
+                toRemove.push(key);
+            }
+        }
+        for (const key of toRemove) ls.removeItem(key);
+    }
+
+    /**
+     * Returns an array of class names whose java-modified flag is currently set.
+     * Used when serialising the flag state into an export archive or git commit.
+     * @returns {string[]}
+     */
+    static getAllJavaModifiedClassNames() {
+        const result = [];
+        const ls = globalThis.localStorage;
+        if (!ls) return result;
+        for (let i = 0; i < ls.length; i++) {
+            const key = ls.key(i);
+            if (key?.startsWith(this.JAVA_MODIFIED_KEY_PREFIX) && ls.getItem(key) === '1') {
+                result.push(key.slice(this.JAVA_MODIFIED_KEY_PREFIX.length));
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Clears all existing java-modified flags and restores the supplied set.
+     * Also wipes the last-generated-code cache for every class so stale
+     * baselines can't trigger false positives while the IDE settles after a
+     * clone, pull, or import.
+     * Used when importing an export archive or reading from a git clone/pull.
+     * @param {string[]} classNames – class names (without .java) to flag as modified
+     */
+    static restoreJavaModifiedClassNames(classNames) {
+        const ls = globalThis.localStorage;
+        if (!ls) return;
+        // Remove all existing flags AND all generated-code cache entries.
+        const toRemove = [];
+        for (let i = 0; i < ls.length; i++) {
+            const key = ls.key(i);
+            if (key?.startsWith(this.JAVA_MODIFIED_KEY_PREFIX) ||
+                key?.startsWith(this.JAVA_GENERATED_KEY_PREFIX)) {
+                toRemove.push(key);
+            }
+        }
+        for (const key of toRemove) ls.removeItem(key);
+        // Set the incoming flags.
+        for (const name of classNames) {
+            this.setJavaModified(name, true);
+        }
+    }
+
     // ── Java-modified flag ────────────────────────────────────────────────────
 
     /**

--- a/custom-generator-codelab/src/utils/LocalStorageManager.js
+++ b/custom-generator-codelab/src/utils/LocalStorageManager.js
@@ -2,6 +2,8 @@ class LocalStorageManager {
 
     static WORKSPACE_STORAGE_KEY = '';
     static CTR_STORAGE_KEY = 'constructors';
+    static JAVA_MODIFIED_KEY_PREFIX  = 'javaModified_';
+    static JAVA_GENERATED_KEY_PREFIX = 'javaGenerated_';
     
     static clearConstructors(className) {
         if(className == null || className === '') {
@@ -59,6 +61,9 @@ class LocalStorageManager {
         globalThis.localStorage?.removeItem(key);
         // Also remove legacy .xml key if present.
         globalThis.localStorage?.removeItem(this.WORKSPACE_STORAGE_KEY + className + '.xml');
+        // Clean up java-modified flag and generated-code cache.
+        globalThis.localStorage?.removeItem(this.JAVA_MODIFIED_KEY_PREFIX  + className);
+        globalThis.localStorage?.removeItem(this.JAVA_GENERATED_KEY_PREFIX + className);
     }
 
     static renameClass(className, newClassName) {
@@ -80,6 +85,20 @@ class LocalStorageManager {
                 delete ctrs[className];
                 globalThis.localStorage.setItem(this.CTR_STORAGE_KEY, JSON.stringify(ctrs));
             }
+        }
+
+        // Migrate java-modified flag.
+        const modifiedVal = globalThis.localStorage?.getItem(this.JAVA_MODIFIED_KEY_PREFIX + className);
+        if (modifiedVal !== null) {
+            globalThis.localStorage.setItem(this.JAVA_MODIFIED_KEY_PREFIX + newClassName, modifiedVal);
+            globalThis.localStorage.removeItem(this.JAVA_MODIFIED_KEY_PREFIX + className);
+        }
+
+        // Migrate last-generated-code cache.
+        const generatedVal = globalThis.localStorage?.getItem(this.JAVA_GENERATED_KEY_PREFIX + className);
+        if (generatedVal !== null) {
+            globalThis.localStorage.setItem(this.JAVA_GENERATED_KEY_PREFIX + newClassName, generatedVal);
+            globalThis.localStorage.removeItem(this.JAVA_GENERATED_KEY_PREFIX + className);
         }
     }
 
@@ -114,6 +133,58 @@ class LocalStorageManager {
     static saveWorkspace(className, data) {
         const key = this.WORKSPACE_STORAGE_KEY + className + '.json';
         globalThis.localStorage?.setItem(key, JSON.stringify(data));
+    }
+
+    // ── Java-modified flag ────────────────────────────────────────────────────
+
+    /**
+     * Returns true when the user has manually edited the Java code for this class
+     * after the last Blockly-generated push, making the Blockly workspace stale.
+     * @param {string} className
+     * @returns {boolean}
+     */
+    static isJavaModified(className) {
+        if (!className) return false;
+        return globalThis.localStorage?.getItem(this.JAVA_MODIFIED_KEY_PREFIX + className) === '1';
+    }
+
+    /**
+     * Sets or clears the java-modified flag for a class.
+     * @param {string}  className
+     * @param {boolean} modified
+     */
+    static setJavaModified(className, modified) {
+        if (!className) return;
+        const key = this.JAVA_MODIFIED_KEY_PREFIX + className;
+        if (modified) {
+            globalThis.localStorage?.setItem(key, '1');
+        } else {
+            globalThis.localStorage?.removeItem(key);
+        }
+    }
+
+    // ── Last Blockly-generated code cache ────────────────────────────────────
+
+    /**
+     * Persists the Java code that was last pushed by Blockly so we can later
+     * compare it against the IDE content to detect manual edits.
+     * @param {string} className
+     * @param {string} code
+     */
+    static saveLastGeneratedCode(className, code) {
+        if (!className) return;
+        globalThis.localStorage?.setItem(this.JAVA_GENERATED_KEY_PREFIX + className, code);
+    }
+
+    /**
+     * Returns the last Blockly-generated Java code for this class, or null if
+     * Blockly has never pushed code for it.
+     * @param {string} className
+     * @returns {string|null}
+     */
+    static loadLastGeneratedCode(className) {
+        if (!className) return null;
+        return globalThis.localStorage?.getItem(this.JAVA_GENERATED_KEY_PREFIX + className) ?? null;
     }
 }
 

--- a/custom-generator-codelab/src/utils/LocalStorageManager.js
+++ b/custom-generator-codelab/src/utils/LocalStorageManager.js
@@ -100,18 +100,6 @@ class LocalStorageManager {
             globalThis.localStorage?.setItem(this.JAVA_GENERATED_KEY_PREFIX + newClassName, generatedVal);
             globalThis.localStorage?.removeItem(this.JAVA_GENERATED_KEY_PREFIX + className);
         }
-        modifiedVal = globalThis.localStorage?.getItem(this.JAVA_MODIFIED_KEY_PREFIX + className);
-        if (modifiedVal != null) {
-            globalThis.localStorage?.setItem(this.JAVA_MODIFIED_KEY_PREFIX + newClassName, modifiedVal);
-            globalThis.localStorage?.removeItem(this.JAVA_MODIFIED_KEY_PREFIX + className);
-        }
-
-        // Migrate last-generated-code cache.
-        generatedVal = globalThis.localStorage?.getItem(this.JAVA_GENERATED_KEY_PREFIX + className);
-        if (generatedVal != null) {
-            globalThis.localStorage?.setItem(this.JAVA_GENERATED_KEY_PREFIX + newClassName, generatedVal);
-            globalThis.localStorage?.removeItem(this.JAVA_GENERATED_KEY_PREFIX + className);
-        }
     }
 
     static createClass(className) {

--- a/custom-generator-codelab/src/utils/LocalStorageManager.js
+++ b/custom-generator-codelab/src/utils/LocalStorageManager.js
@@ -83,22 +83,34 @@ class LocalStorageManager {
             if (ctrs[className] !== undefined) {
                 ctrs[newClassName] = ctrs[className];
                 delete ctrs[className];
-                globalThis.localStorage.setItem(this.CTR_STORAGE_KEY, JSON.stringify(ctrs));
+                globalThis.localStorage?.setItem(this.CTR_STORAGE_KEY, JSON.stringify(ctrs));
             }
         }
 
         // Migrate java-modified flag.
         const modifiedVal = globalThis.localStorage?.getItem(this.JAVA_MODIFIED_KEY_PREFIX + className);
-        if (modifiedVal !== null) {
-            globalThis.localStorage.setItem(this.JAVA_MODIFIED_KEY_PREFIX + newClassName, modifiedVal);
-            globalThis.localStorage.removeItem(this.JAVA_MODIFIED_KEY_PREFIX + className);
+        if (modifiedVal != null) {
+            globalThis.localStorage?.setItem(this.JAVA_MODIFIED_KEY_PREFIX + newClassName, modifiedVal);
+            globalThis.localStorage?.removeItem(this.JAVA_MODIFIED_KEY_PREFIX + className);
         }
 
         // Migrate last-generated-code cache.
         const generatedVal = globalThis.localStorage?.getItem(this.JAVA_GENERATED_KEY_PREFIX + className);
-        if (generatedVal !== null) {
-            globalThis.localStorage.setItem(this.JAVA_GENERATED_KEY_PREFIX + newClassName, generatedVal);
-            globalThis.localStorage.removeItem(this.JAVA_GENERATED_KEY_PREFIX + className);
+        if (generatedVal != null) {
+            globalThis.localStorage?.setItem(this.JAVA_GENERATED_KEY_PREFIX + newClassName, generatedVal);
+            globalThis.localStorage?.removeItem(this.JAVA_GENERATED_KEY_PREFIX + className);
+        }
+        modifiedVal = globalThis.localStorage?.getItem(this.JAVA_MODIFIED_KEY_PREFIX + className);
+        if (modifiedVal != null) {
+            globalThis.localStorage?.setItem(this.JAVA_MODIFIED_KEY_PREFIX + newClassName, modifiedVal);
+            globalThis.localStorage?.removeItem(this.JAVA_MODIFIED_KEY_PREFIX + className);
+        }
+
+        // Migrate last-generated-code cache.
+        generatedVal = globalThis.localStorage?.getItem(this.JAVA_GENERATED_KEY_PREFIX + className);
+        if (generatedVal != null) {
+            globalThis.localStorage?.setItem(this.JAVA_GENERATED_KEY_PREFIX + newClassName, generatedVal);
+            globalThis.localStorage?.removeItem(this.JAVA_GENERATED_KEY_PREFIX + className);
         }
     }
 

--- a/custom-generator-codelab/src/utils/WorkspaceManager.js
+++ b/custom-generator-codelab/src/utils/WorkspaceManager.js
@@ -515,7 +515,6 @@ export class WorkspaceManager {
     // Update overlay immediately for the newly active class (flag may have
     // just been restored from the archive).
     if (activeFile) {
-      const { BlocklyOverlayManager } = await import('./BlocklyOverlayManager.js');
       BlocklyOverlayManager.updateForClass(activeFile.replace('.java', ''));
     }
 

--- a/custom-generator-codelab/src/utils/WorkspaceManager.js
+++ b/custom-generator-codelab/src/utils/WorkspaceManager.js
@@ -23,6 +23,7 @@ import { IdeBridge } from './IdeBridge.js';
 import { GitService } from './GitService.js';
 import { ToolboxConfigManager } from './ToolboxConfigManager.js';
 import { GitDialog } from './GitDialog.js';
+import { BlocklyOverlayManager } from './BlocklyOverlayManager.js';
 import emptyTemplate from '../emptyTemplate.json';
 import * as Blockly from 'blockly/core';
 import { load } from '../serialization.js';
@@ -211,6 +212,11 @@ export class WorkspaceManager {
     // Clear constructor data.
     LocalStorageManager.clearAllConstructors();
 
+    // Clear java-modified flags and generated-code cache so no overlay
+    // is shown after the reset.
+    LocalStorageManager.clearAllJavaModifiedData();
+    BlocklyOverlayManager.hide();
+
     // Apply the full-active config so the blank workspace has an explicit
     // blockly-config.json (all categories on) rather than implicit defaults.
     ToolboxConfigManager.apply(FULL_ACTIVE_CONFIG, ws);
@@ -323,6 +329,12 @@ export class WorkspaceManager {
       zip.file('blockly-config.json', JSON.stringify(toolboxConfig, null, 2));
     } catch { /* skip */ }
 
+    // ── Blockly-override metadata (b2j-metadata.json) ────────────────────
+    // Stores which classes have been manually edited so the flag survives
+    // a round-trip through export + import.
+    const modifiedClasses = LocalStorageManager.getAllJavaModifiedClassNames();
+    zip.file('b2j-metadata.json', JSON.stringify({ javaModified: modifiedClasses }, null, 2));
+
     // ── Generate and download -------------------------------------------
     const blob = await zip.generateAsync({ type: 'blob', compression: 'DEFLATE' });
     const url  = URL.createObjectURL(blob);
@@ -428,6 +440,17 @@ export class WorkspaceManager {
         continue;
       }
 
+      if (normalised === 'b2j-metadata.json') {
+        // Restore java-modified flags from the archive.
+        try {
+          const meta = JSON.parse(await zipEntry.async('string'));
+          if (Array.isArray(meta?.javaModified)) {
+            LocalStorageManager.restoreJavaModifiedClassNames(meta.javaModified);
+          }
+        } catch { /* ignore malformed metadata */ }
+        continue;
+      }
+
       // Only process files inside src/.
       if (!normalised.startsWith('src/')) continue;
 
@@ -487,6 +510,13 @@ export class WorkspaceManager {
     const activeFile = IdeBridge.selected_file_name;
     if (activeFile) {
       load(ws);
+    }
+
+    // Update overlay immediately for the newly active class (flag may have
+    // just been restored from the archive).
+    if (activeFile) {
+      const { BlocklyOverlayManager } = await import('./BlocklyOverlayManager.js');
+      BlocklyOverlayManager.updateForClass(activeFile.replace('.java', ''));
     }
 
     return counts;


### PR DESCRIPTION
Implement an overlay that prevents Blockly from overwriting manually edited Java code. The overlay appears when manual edits are detected, prompting the user for confirmation before proceeding with Blockly changes. This enhancement improves user experience by safeguarding manual modifications.

closes #43