### PR TITLE
Implement inheritance support with java_extends and java_super_call blocks

### DIFF
--- a/custom-generator-codelab/src/blocks/constructor.js
+++ b/custom-generator-codelab/src/blocks/constructor.js
@@ -264,6 +264,36 @@ Blockly.Blocks['callconstructor'] = {
     }
   },
 
+  /** Creates a dropdown field whose validator calls updateShape_ on change. */
+  _makeDropdown_: function() {
+    const dd = new Blockly.FieldDropdown(() => this.getConstructorOptions_());
+    dd.setValidator((newValue) => {
+      if (!this._updatingShape_ && newValue !== this.getFieldValue('CONSTRUCTOR_CLASS')) {
+        this.updateShape_(newValue);
+      }
+      return newValue;
+    });
+    return dd;
+  },
+
+  /**
+   * Forces a dropdown field to accept a value even if it is not yet in the
+   * dynamically-computed options list.
+   */
+  _forceSetField_: function(field, val, displayLabel) {
+    if (!field) return;
+    const origGet = field.getOptions.bind(field);
+    field.getOptions = () => {
+      const opts = origGet();
+      if (!opts.some(([, v]) => v === val)) {
+        opts.push([displayLabel || val, val]);
+      }
+      return opts;
+    };
+    field.setValue(val);          // events are already disabled by the caller
+    field.getOptions = origGet;   // restore original getter
+  },
+
   _updateShapeInner_: function (value) {
     // Accept value as argument (called from loadExtraState / validator)
     // or fall back to reading the field (called from onchange).
@@ -275,7 +305,7 @@ Blockly.Blocks['callconstructor'] = {
     const savedConns = {};
     for (const arg of (this.arguments_ || [])) {
       const inp = this.getInput('ARG_' + arg);
-      if (inp && inp.connection) savedConns[arg] = inp.connection.targetConnection;
+      if (inp?.connection) savedConns[arg] = inp.connection.targetConnection;
     }
 
     // ── Remove all existing inputs ──────────────────────────────────────
@@ -285,39 +315,7 @@ Blockly.Blocks['callconstructor'] = {
     if (this.getInput('TOP_LINE')) this.removeInput('TOP_LINE');
 
     // ── Helper: create a dropdown with a shape-update validator ──────────
-    // The validator fires synchronously BEFORE Blockly dispatches the
-    // BLOCK_CHANGE event, so the block shape is always consistent with the
-    // field value by the time any workspace change listener serializes it.
-    // The _updatingShape_ guard prevents validator → updateShape_ →
-    // make new dropdown → validator re-entrancy.
-    const block = this;
-    const makeDropdown = () => {
-      const dd = new Blockly.FieldDropdown(() => block.getConstructorOptions_());
-      dd.setValidator(function (newValue) {
-        if (!block._updatingShape_ && newValue !== block.getFieldValue('CONSTRUCTOR_CLASS')) {
-          block.updateShape_(newValue);
-        }
-        return newValue; // accept the value
-      });
-      return dd;
-    };
-
-    // ── Helper: force-set the field value ───────────────────────────────
-    // Temporarily patches getOptions so the value is accepted even if
-    // the dynamic option list hasn't been re-evaluated yet.
-    const forceSetField = (field, val, displayLabel) => {
-      if (!field) return;
-      const origGet = field.getOptions.bind(field);
-      field.getOptions = () => {
-        const opts = origGet();
-        if (!opts.find(([, v]) => v === val)) {
-          opts.push([displayLabel || val, val]);
-        }
-        return opts;
-      };
-      field.setValue(val);          // events are already disabled by the caller
-      field.getOptions = origGet;   // restore original getter
-    };
+    // Delegates to this._makeDropdown_() which is defined as a block method.
 
     // ── NONE / empty ────────────────────────────────────────────────────
     if (!value || value === 'NONE') {
@@ -325,7 +323,7 @@ Blockly.Blocks['callconstructor'] = {
       this.setOutput(true, 'CLASS');
       this.appendDummyInput('TOP_LINE')
         .appendField('new ')
-        .appendField(makeDropdown(), 'CONSTRUCTOR_CLASS');
+        .appendField(this._makeDropdown_(), 'CONSTRUCTOR_CLASS');
       return;
     }
 
@@ -343,16 +341,16 @@ Blockly.Blocks['callconstructor'] = {
       // ── No-arg constructor ────────────────────────────────────────────
       this.appendDummyInput('TOP_LINE')
         .appendField('new ')
-        .appendField(makeDropdown(), 'CONSTRUCTOR_CLASS');
-      forceSetField(this.getField('CONSTRUCTOR_CLASS'), value, displayLabel);
+        .appendField(this._makeDropdown_(), 'CONSTRUCTOR_CLASS');
+      this._forceSetField_(this.getField('CONSTRUCTOR_CLASS'), value, displayLabel);
     } else {
       // ── Constructor with args ─────────────────────────────────────────
       const firstArg = this.arguments_[0];
       this.appendValueInput('ARG_' + firstArg)
         .appendField('new ')
-        .appendField(makeDropdown(), 'CONSTRUCTOR_CLASS')
+        .appendField(this._makeDropdown_(), 'CONSTRUCTOR_CLASS')
         .appendField('( ' + firstArg + (this.arguments_.length > 1 ? ' ,' : ' )'));
-      forceSetField(this.getField('CONSTRUCTOR_CLASS'), value, displayLabel);
+      this._forceSetField_(this.getField('CONSTRUCTOR_CLASS'), value, displayLabel);
 
       // Restore first-arg connection.
       if (savedConns[firstArg]?.getSourceBlock?.()?.workspace) {
@@ -370,7 +368,7 @@ Blockly.Blocks['callconstructor'] = {
         }
       }
     }
-  }
+  },
 };
 
 // ── Colour shared by the two inheritance blocks ───────────────────────────
@@ -381,11 +379,10 @@ const INHERIT_COLOUR = '#5B6B8A';
 // ─────────────────────────────────────────────────────────────────────────────
 Blockly.Blocks['java_extends'] = {
   init: function () {
-    const block = this;
     this.appendDummyInput('TOP_LINE')
       .appendField('erbt von')
       .appendField(
-        new Blockly.FieldDropdown(() => block.getClassOptions_()),
+        new Blockly.FieldDropdown(() => this.getClassOptions_()),
         'PARENT_CLASS'
       );
     this.setPreviousStatement(false, null);
@@ -422,7 +419,7 @@ Blockly.Blocks['java_extends'] = {
         const origGetOptions = field.getOptions.bind(field);
         field.getOptions = () => {
           const opts = origGetOptions();
-          if (!opts.find(([, v]) => v === saved)) opts.push([saved, saved]);
+          if (!opts.some(([, v]) => v === saved)) opts.push([saved, saved]);
           return opts;
         };
         field.setValue(saved);
@@ -478,11 +475,50 @@ Blockly.Blocks['java_super_call'] = {
     const needsRefresh =
       event.type === Blockly.Events.FINISHED_LOADING ||
       (event.type === Blockly.Events.BLOCK_CREATE &&
-        event.ids && event.ids.includes(this.id)) ||
+        event.ids?.includes(this.id)) ||
       (event.type === Blockly.Events.BLOCK_CHANGE &&
         event.name === 'PARENT_CLASS');
     if (needsRefresh) {
       this.refreshFromParent_();
+    }
+  },
+
+  /** Save existing ARG connections and return them as an array. */
+  _saveArgConnections_: function() {
+    const saved = [];
+    for (let i = 0; this.getInput('ARG' + i); i++) {
+      saved[i] = this.getInput('ARG' + i).connection?.targetConnection;
+    }
+    return saved;
+  },
+
+  /** Remove all existing ARG and TOP_LINE inputs. */
+  _removeArgInputs_: function() {
+    let i = 0;
+    while (this.getInput('ARG' + i)) { this.removeInput('ARG' + i); i++; }
+    if (this.getInput('TOP_LINE')) this.removeInput('TOP_LINE');
+  },
+
+  /** Build TOP_LINE + ARG inputs from argNames, restoring saved connections. */
+  _buildArgInputsShape_: function(saved) {
+    if (this.argNames_.length === 0) {
+      this.appendDummyInput('TOP_LINE').appendField('super()', 'SUPER_LABEL');
+      return;
+    }
+    const label0 = this.argNames_[0];
+    this.appendValueInput('ARG0')
+      .appendField('super( ' + label0 + (this.argNames_.length > 1 ? ' ,' : ' )'));
+    if (saved[0]?.getSourceBlock()?.workspace) {
+      this.getInput('ARG0').connection.connect(saved[0]);
+    }
+    for (let j = 1; j < this.argNames_.length; j++) {
+      const label = this.argNames_[j];
+      this.appendValueInput('ARG' + j)
+        .setAlign(Blockly.inputs.Align.RIGHT)
+        .appendField(label + (j + 1 === this.argNames_.length ? ' )' : ' ,'));
+      if (saved[j]?.getSourceBlock()?.workspace) {
+        this.getInput('ARG' + j).connection.connect(saved[j]);
+      }
     }
   },
 
@@ -493,44 +529,10 @@ Blockly.Blocks['java_super_call'] = {
    * Existing connections are preserved if the arg count doesn't shrink.
    */
   updateShape_: function (argNames) {
-    // Save existing connections.
-    const saved = [];
-    for (let i = 0; this.getInput('ARG' + i); i++) {
-      const conn = this.getInput('ARG' + i).connection;
-      saved[i] = conn && conn.targetConnection;
-    }
-
-    // Remove old ARG inputs.
-    let i = 0;
-    while (this.getInput('ARG' + i)) { this.removeInput('ARG' + i); i++; }
-
+    const saved = this._saveArgConnections_();
+    this._removeArgInputs_();
     this.argNames_ = argNames || [];
-
-    // Rebuild TOP_LINE and arg inputs.
-    if (this.getInput('TOP_LINE')) { this.removeInput('TOP_LINE'); }
-
-    if (this.argNames_.length === 0) {
-      // No args: plain dummy with 'super()' label.
-      this.appendDummyInput('TOP_LINE').appendField('super()', 'SUPER_LABEL');
-    } else {
-      // First arg connector on the same row as the 'super(' label.
-      const label0 = this.argNames_[0];
-      this.appendValueInput('ARG0')
-        .appendField('super( ' + label0 + (this.argNames_.length > 1 ? ' ,' : ' )'));
-      if (saved[0] && saved[0].getSourceBlock().workspace) {
-        this.getInput('ARG0').connection.connect(saved[0]);
-      }
-      // Remaining args below, right-aligned.
-      for (let j = 1; j < this.argNames_.length; j++) {
-        const label = this.argNames_[j];
-        this.appendValueInput('ARG' + j)
-          .setAlign(Blockly.inputs.Align.RIGHT)
-          .appendField(label + (j + 1 === this.argNames_.length ? ' )' : ' ,'));
-        if (saved[j] && saved[j].getSourceBlock().workspace) {
-          this.getInput('ARG' + j).connection.connect(saved[j]);
-        }
-      }
-    }
+    this._buildArgInputsShape_(saved);
   },
 
   saveExtraState: function () {

--- a/custom-generator-codelab/src/blocks/constructor.js
+++ b/custom-generator-codelab/src/blocks/constructor.js
@@ -294,3 +294,162 @@ Blockly.Blocks['callconstructor'] = {
     }
   }
 };
+
+// ── Colour shared by the two inheritance blocks ───────────────────────────
+const INHERIT_COLOUR = '#5B6B8A';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// java_extends – declares the parent class (inheritance)
+// ─────────────────────────────────────────────────────────────────────────────
+Blockly.Blocks['java_extends'] = {
+  init: function () {
+    const block = this;
+    this.appendDummyInput('TOP_LINE')
+      .appendField('erbt von')
+      .appendField(
+        new Blockly.FieldDropdown(() => block.getClassOptions_()),
+        'PARENT_CLASS'
+      );
+    this.setPreviousStatement(false, null);
+    this.setNextStatement(false, null);
+    this.setColour(INHERIT_COLOUR);
+    this.setTooltip('Legt die Elternklasse (Vererbung) für diese Klasse fest.');
+    this.setHelpUrl('');
+  },
+
+  /** Build dropdown options from all classes registered in LocalStorage. */
+  getClassOptions_: function () {
+    const allCtrs = LocalStorageManager.getAllConstructors();
+    const options = Object.keys(allCtrs)
+      .filter(name => name !== getClassName())   // exclude the current class
+      .map(name => [name, name]);
+    if (options.length === 0) {
+      options.push(['(keine)', 'NONE']);
+    }
+    return options;
+  },
+
+  saveExtraState: function () {
+    return { parentClass: this.getFieldValue('PARENT_CLASS') || 'NONE' };
+  },
+
+  loadExtraState: function (state) {
+    const saved = (state && state.parentClass) || 'NONE';
+    if (saved && saved !== 'NONE') {
+      // The dynamic dropdown may not include the saved value until options are
+      // computed; force-set the field value after deserialization.
+      const field = this.getField('PARENT_CLASS');
+      if (field) {
+        // Temporarily extend the option list so setValue doesn't reject it.
+        const origGetOptions = field.getOptions.bind(field);
+        field.getOptions = () => {
+          const opts = origGetOptions();
+          if (!opts.find(([, v]) => v === saved)) opts.push([saved, saved]);
+          return opts;
+        };
+        field.setValue(saved);
+        field.getOptions = origGetOptions;
+      }
+    }
+  },
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// java_super_call – calls the parent constructor  super(arg1, arg2, …)
+// Arguments are auto-determined from the parent class constructor stored in
+// LocalStorage (populated when the parent class is generated).
+// ─────────────────────────────────────────────────────────────────────────────
+Blockly.Blocks['java_super_call'] = {
+  init: function () {
+    this.argNames_ = [];
+    this.appendDummyInput('TOP_LINE').appendField('super()', 'SUPER_LABEL');
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(INHERIT_COLOUR);
+    this.setTooltip('Ruft den Konstruktor der Elternklasse auf.');
+    this.setHelpUrl('');
+  },
+
+  /** Finds the parent class from the java_extends block in the same workspace. */
+  _getParentClass: function () {
+    if (!this.workspace) return null;
+    const extendsBlocks = this.workspace.getBlocksByType('java_extends', false);
+    if (!extendsBlocks.length) return null;
+    const val = extendsBlocks[0].getFieldValue('PARENT_CLASS');
+    return (val && val !== 'NONE') ? val : null;
+  },
+
+  /**
+   * Reads the parent class's constructors from LocalStorage and rebuilds the
+   * value inputs.  Called automatically when the workspace finishes loading or
+   * when the java_extends block changes.
+   */
+  refreshFromParent_: function () {
+    const parentClass = this._getParentClass();
+    let argNames = [];
+    if (parentClass) {
+      const allCtrs = LocalStorageManager.getAllConstructors();
+      const ctrs = allCtrs[parentClass] || [];
+      if (ctrs.length > 0) argNames = ctrs[0].arguments || [];
+    }
+    this.updateShape_(argNames);
+  },
+
+  onchange: function (event) {
+    if (!this.workspace || this.isInserted && !this.isInserted()) return;
+    const needsRefresh =
+      event.type === Blockly.Events.FINISHED_LOADING ||
+      (event.type === Blockly.Events.BLOCK_CREATE &&
+        event.ids && event.ids.includes(this.id)) ||
+      (event.type === Blockly.Events.BLOCK_CHANGE &&
+        event.name === 'PARENT_CLASS');
+    if (needsRefresh) {
+      this.refreshFromParent_();
+    }
+  },
+
+  /**
+   * Rebuilds value inputs ARG0..ARGn from argNames.
+   * Existing connections are preserved if the arg count doesn't shrink.
+   */
+  updateShape_: function (argNames) {
+    // Save existing connections.
+    const saved = [];
+    for (let i = 0; this.getInput('ARG' + i); i++) {
+      const conn = this.getInput('ARG' + i).connection;
+      saved[i] = conn && conn.targetConnection;
+    }
+
+    // Remove old ARG inputs.
+    let i = 0;
+    while (this.getInput('ARG' + i)) { this.removeInput('ARG' + i); i++; }
+
+    this.argNames_ = argNames || [];
+
+    // Update the TOP_LINE label.
+    const label = this.argNames_.length
+      ? 'super(' + this.argNames_.join(', ') + ')'
+      : 'super()';
+    this.setFieldValue(label, 'SUPER_LABEL');
+
+    // Recreate value inputs with proper type-check.
+    for (let j = 0; j < this.argNames_.length; j++) {
+      this.appendValueInput('ARG' + j)
+        .setCheck(null)
+        .setAlign(Blockly.inputs.Align.RIGHT)
+        .appendField(this.argNames_[j]);
+      // Restore previous connection if still alive.
+      if (saved[j] && saved[j].getSourceBlock().workspace) {
+        this.getInput('ARG' + j).connection.connect(saved[j]);
+      }
+    }
+  },
+
+  saveExtraState: function () {
+    return { argNames: this.argNames_ };
+  },
+
+  loadExtraState: function (state) {
+    this.updateShape_((state && state.argNames) || []);
+  },
+};

--- a/custom-generator-codelab/src/blocks/constructor.js
+++ b/custom-generator-codelab/src/blocks/constructor.js
@@ -175,31 +175,15 @@ Blockly.Blocks['argument_input'] = {
 /// Neuer Block für den Aufruf des benutzerdefinierten Blocks
 Blockly.Blocks['callconstructor'] = {
   init: function () {
-    const block = this;
-    this.appendDummyInput('TOP_LINE')
-      .appendField("new ")
-      .appendField(
-        new Blockly.FieldDropdown(
-          () => block.getConstructorOptions_(),
-          function (newValue) {
-            // Validator fires synchronously when the field value is set,
-            // including during JSON deserialization — before connections are
-            // restored. Create the ARG_ inputs here so they exist in time.
-            if (block.updateShape_) {
-              block.updateShape_(newValue);
-            }
-            return newValue;
-          }
-        ),
-        'CONSTRUCTOR_CLASS'
-      );
+    this.arguments_ = [];
+    this._updatingShape_ = false;
     this.setPreviousStatement(false, null);
     this.setNextStatement(false, null);
     this.setOutput(true, 'CLASS');
     this.setColour(230);
     this.setTooltip('');
     this.setHelpUrl('');
-    this.arguments_ = [];
+    // updateShape_ builds TOP_LINE (with the dropdown) and any ARG inputs.
     this.updateShape_();
   },
 
@@ -256,23 +240,47 @@ Blockly.Blocks['callconstructor'] = {
   },
 
   updateShape_: function (value) {
+    // Guard against re-entrancy (FieldDropdown init triggers the validator
+    // which would call updateShape_ again).
+    if (this._updatingShape_) return;
+    this._updatingShape_ = true;
+    try {
+      this._updateShapeInner_(value);
+    } finally {
+      this._updatingShape_ = false;
+    }
+  },
+
+  _updateShapeInner_: function (value) {
     // Accept value as argument (called from validator before field is committed)
     // or fall back to reading the field (called from onchange / loadExtraState).
     if (value === undefined) {
       value = this.getFieldValue('CONSTRUCTOR_CLASS');
     }
 
-    // Remove inputs created for previous argument list.
-    for (const arg of this.arguments_) {
-      const inputId = 'ARG_' + arg;
-      if (this.getInput(inputId)) {
-        this.removeInput(inputId);
-      }
+    // Save connections from existing ARG inputs.
+    const savedConns = {};
+    for (const arg of (this.arguments_ || [])) {
+      const inp = this.getInput('ARG_' + arg);
+      if (inp && inp.connection) savedConns[arg] = inp.connection.targetConnection;
     }
+
+    // Remove all existing ARG inputs.
+    for (const arg of (this.arguments_ || [])) {
+      if (this.getInput('ARG_' + arg)) this.removeInput('ARG_' + arg);
+    }
+    // Remove TOP_LINE so we can recreate it in the right style.
+    if (this.getInput('TOP_LINE')) this.removeInput('TOP_LINE');
 
     if (!value || value === 'NONE') {
       this.arguments_ = [];
       this.setOutput(true, 'CLASS');
+      const block = this;
+      const dd = new Blockly.FieldDropdown(
+        () => block.getConstructorOptions_(),
+        function (newVal) { if (block.updateShape_) block.updateShape_(newVal); return newVal; }
+      );
+      this.appendDummyInput('TOP_LINE').appendField('new ').appendField(dd, 'CONSTRUCTOR_CLASS');
       return;
     }
 
@@ -284,12 +292,55 @@ Blockly.Blocks['callconstructor'] = {
 
     this.setOutput(true, className);
 
-    for (const arg of this.arguments_) {
-      const inputId = 'ARG_' + arg;
-      if (!this.getInput(inputId)) {
-        this.appendValueInput(inputId)
-          .setCheck(null)
-          .appendField(arg);
+    const block = this;
+    const makeDropdown = () => {
+      const dd = new Blockly.FieldDropdown(
+        () => block.getConstructorOptions_(),
+        function (newVal) { if (block.updateShape_) block.updateShape_(newVal); return newVal; }
+      );
+      return dd;
+    };
+
+    if (this.arguments_.length === 0) {
+      const dd = makeDropdown();
+      this.appendDummyInput('TOP_LINE').appendField('new ').appendField(dd, 'CONSTRUCTOR_CLASS');
+      // Force the field to the correct value after appending.
+      const field = this.getField('CONSTRUCTOR_CLASS');
+      if (field && value) {
+        const origOpts = field.getOptions.bind(field);
+        field.getOptions = () => { const opts = origOpts(); if (!opts.find(([, v]) => v === value)) opts.push([className + '()', value]); return opts; };
+        field.setValue(value);
+        field.getOptions = origOpts;
+      }
+    } else {
+      // First arg connector on the same row as 'new ClassName('.
+      const firstArg = this.arguments_[0];
+      const dd = makeDropdown();
+      this.appendValueInput('ARG_' + firstArg)
+        .appendField('new ')
+        .appendField(dd, 'CONSTRUCTOR_CLASS')
+        .appendField('( ' + firstArg + (this.arguments_.length > 1 ? ' ,' : ' )'));
+      // Force the field to the correct value.
+      const field = this.getField('CONSTRUCTOR_CLASS');
+      if (field && value) {
+        const origOpts = field.getOptions.bind(field);
+        field.getOptions = () => { const opts = origOpts(); if (!opts.find(([, v]) => v === value)) opts.push([className + '(' + this.arguments_.join(', ') + ')', value]); return opts; };
+        field.setValue(value);
+        field.getOptions = origOpts;
+      }
+      // Restore first-arg connection.
+      if (savedConns[firstArg] && savedConns[firstArg].getSourceBlock && savedConns[firstArg].getSourceBlock().workspace) {
+        this.getInput('ARG_' + firstArg).connection.connect(savedConns[firstArg]);
+      }
+      // Remaining args below, right-aligned.
+      for (let j = 1; j < this.arguments_.length; j++) {
+        const arg = this.arguments_[j];
+        this.appendValueInput('ARG_' + arg)
+          .setAlign(Blockly.inputs.Align.RIGHT)
+          .appendField(arg + (j + 1 === this.arguments_.length ? ' )' : ' ,'));
+        if (savedConns[arg] && savedConns[arg].getSourceBlock && savedConns[arg].getSourceBlock().workspace) {
+          this.getInput('ARG_' + arg).connection.connect(savedConns[arg]);
+        }
       }
     }
   }
@@ -410,6 +461,8 @@ Blockly.Blocks['java_super_call'] = {
 
   /**
    * Rebuilds value inputs ARG0..ARGn from argNames.
+   * The first arg connector sits on the same row as the 'super(' label,
+   * matching the visual style of normal method-call blocks.
    * Existing connections are preserved if the arg count doesn't shrink.
    */
   updateShape_: function (argNames) {
@@ -426,21 +479,29 @@ Blockly.Blocks['java_super_call'] = {
 
     this.argNames_ = argNames || [];
 
-    // Update the TOP_LINE label.
-    const label = this.argNames_.length
-      ? 'super(' + this.argNames_.join(', ') + ')'
-      : 'super()';
-    this.setFieldValue(label, 'SUPER_LABEL');
+    // Rebuild TOP_LINE and arg inputs.
+    if (this.getInput('TOP_LINE')) { this.removeInput('TOP_LINE'); }
 
-    // Recreate value inputs with proper type-check.
-    for (let j = 0; j < this.argNames_.length; j++) {
-      this.appendValueInput('ARG' + j)
-        .setCheck(null)
-        .setAlign(Blockly.inputs.Align.RIGHT)
-        .appendField(this.argNames_[j]);
-      // Restore previous connection if still alive.
-      if (saved[j] && saved[j].getSourceBlock().workspace) {
-        this.getInput('ARG' + j).connection.connect(saved[j]);
+    if (this.argNames_.length === 0) {
+      // No args: plain dummy with 'super()' label.
+      this.appendDummyInput('TOP_LINE').appendField('super()', 'SUPER_LABEL');
+    } else {
+      // First arg connector on the same row as the 'super(' label.
+      const label0 = this.argNames_[0];
+      this.appendValueInput('ARG0')
+        .appendField('super( ' + label0 + (this.argNames_.length > 1 ? ' ,' : ' )'));
+      if (saved[0] && saved[0].getSourceBlock().workspace) {
+        this.getInput('ARG0').connection.connect(saved[0]);
+      }
+      // Remaining args below, right-aligned.
+      for (let j = 1; j < this.argNames_.length; j++) {
+        const label = this.argNames_[j];
+        this.appendValueInput('ARG' + j)
+          .setAlign(Blockly.inputs.Align.RIGHT)
+          .appendField(label + (j + 1 === this.argNames_.length ? ' )' : ' ,'));
+        if (saved[j] && saved[j].getSourceBlock().workspace) {
+          this.getInput('ARG' + j).connection.connect(saved[j]);
+        }
       }
     }
   },

--- a/custom-generator-codelab/src/blocks/constructor.js
+++ b/custom-generator-codelab/src/blocks/constructor.js
@@ -36,7 +36,10 @@ Blockly.Blocks["defconstructor"] = {
       argument.setAttribute('varid', id);
       container.appendChild(argument);
     }
-    this.updateShape_();
+    // NOTE: do NOT call updateShape_() here.
+    // mutationToDom is called during workspace serialization (save); calling
+    // updateShape_() would fire a BLOCK_CHANGE event from inside the save
+    // listener, causing an endless save → mutate → event → save cycle.
     return container;
   },
 
@@ -229,116 +232,140 @@ Blockly.Blocks['callconstructor'] = {
     }
   },
 
-  onchange: function (event) {
-    if (
-      event.type === Blockly.Events.BLOCK_CHANGE &&
-      event.blockId === this.id &&
-      event.name === 'CONSTRUCTOR_CLASS'
-    ) {
-      this.updateShape_();
-    }
-  },
-
+  /**
+   * Rebuild the block's visual shape (inputs / fields) to match the
+   * currently selected constructor.
+   *
+   * ALL Blockly events are suppressed for the entire rebuild so that
+   * removeInput / appendInput / appendField / setValue cannot fire
+   * BLOCK_CHANGE events that re-trigger the workspace change-listener,
+   * which was the root cause of the infinite loop.
+   *
+   * This is called from the dropdown VALIDATOR (synchronously, before any
+   * Blockly events fire) so that the block shape is always consistent with
+   * the field value at the time any change listener sees it.
+   *
+   * @param {string=} value  Optional explicit value; if omitted the
+   *   current CONSTRUCTOR_CLASS field value is read.
+   */
   updateShape_: function (value) {
-    // Guard against re-entrancy (FieldDropdown init triggers the validator
-    // which would call updateShape_ again).
     if (this._updatingShape_) return;
     this._updatingShape_ = true;
     try {
-      this._updateShapeInner_(value);
+      // ── Suppress every event the rebuild would otherwise emit ──
+      Blockly.Events.disable();
+      try {
+        this._updateShapeInner_(value);
+      } finally {
+        Blockly.Events.enable();
+      }
     } finally {
       this._updatingShape_ = false;
     }
   },
 
   _updateShapeInner_: function (value) {
-    // Accept value as argument (called from validator before field is committed)
-    // or fall back to reading the field (called from onchange / loadExtraState).
+    // Accept value as argument (called from loadExtraState / validator)
+    // or fall back to reading the field (called from onchange).
     if (value === undefined) {
       value = this.getFieldValue('CONSTRUCTOR_CLASS');
     }
 
-    // Save connections from existing ARG inputs.
+    // ── Save connections from existing ARG inputs ────────────────────────
     const savedConns = {};
     for (const arg of (this.arguments_ || [])) {
       const inp = this.getInput('ARG_' + arg);
       if (inp && inp.connection) savedConns[arg] = inp.connection.targetConnection;
     }
 
-    // Remove all existing ARG inputs.
+    // ── Remove all existing inputs ──────────────────────────────────────
     for (const arg of (this.arguments_ || [])) {
       if (this.getInput('ARG_' + arg)) this.removeInput('ARG_' + arg);
     }
-    // Remove TOP_LINE so we can recreate it in the right style.
     if (this.getInput('TOP_LINE')) this.removeInput('TOP_LINE');
 
+    // ── Helper: create a dropdown with a shape-update validator ──────────
+    // The validator fires synchronously BEFORE Blockly dispatches the
+    // BLOCK_CHANGE event, so the block shape is always consistent with the
+    // field value by the time any workspace change listener serializes it.
+    // The _updatingShape_ guard prevents validator → updateShape_ →
+    // make new dropdown → validator re-entrancy.
+    const block = this;
+    const makeDropdown = () => {
+      const dd = new Blockly.FieldDropdown(() => block.getConstructorOptions_());
+      dd.setValidator(function (newValue) {
+        if (!block._updatingShape_ && newValue !== block.getFieldValue('CONSTRUCTOR_CLASS')) {
+          block.updateShape_(newValue);
+        }
+        return newValue; // accept the value
+      });
+      return dd;
+    };
+
+    // ── Helper: force-set the field value ───────────────────────────────
+    // Temporarily patches getOptions so the value is accepted even if
+    // the dynamic option list hasn't been re-evaluated yet.
+    const forceSetField = (field, val, displayLabel) => {
+      if (!field) return;
+      const origGet = field.getOptions.bind(field);
+      field.getOptions = () => {
+        const opts = origGet();
+        if (!opts.find(([, v]) => v === val)) {
+          opts.push([displayLabel || val, val]);
+        }
+        return opts;
+      };
+      field.setValue(val);          // events are already disabled by the caller
+      field.getOptions = origGet;   // restore original getter
+    };
+
+    // ── NONE / empty ────────────────────────────────────────────────────
     if (!value || value === 'NONE') {
       this.arguments_ = [];
       this.setOutput(true, 'CLASS');
-      const block = this;
-      const dd = new Blockly.FieldDropdown(
-        () => block.getConstructorOptions_(),
-        function (newVal) { if (block.updateShape_) block.updateShape_(newVal); return newVal; }
-      );
-      this.appendDummyInput('TOP_LINE').appendField('new ').appendField(dd, 'CONSTRUCTOR_CLASS');
+      this.appendDummyInput('TOP_LINE')
+        .appendField('new ')
+        .appendField(makeDropdown(), 'CONSTRUCTOR_CLASS');
       return;
     }
 
-    // Value format: "ClassName:::arg1,arg2"
+    // ── Parse "ClassName:::arg1,arg2" ───────────────────────────────────
     const sepIdx = value.indexOf(':::');
     const className = sepIdx >= 0 ? value.slice(0, sepIdx) : value;
-    const argsStr = sepIdx >= 0 ? value.slice(sepIdx + 3) : '';
+    const argsStr  = sepIdx >= 0 ? value.slice(sepIdx + 3) : '';
     this.arguments_ = argsStr ? argsStr.split(',').filter(a => a) : [];
 
     this.setOutput(true, className);
 
-    const block = this;
-    const makeDropdown = () => {
-      const dd = new Blockly.FieldDropdown(
-        () => block.getConstructorOptions_(),
-        function (newVal) { if (block.updateShape_) block.updateShape_(newVal); return newVal; }
-      );
-      return dd;
-    };
+    const displayLabel = className + '(' + this.arguments_.join(', ') + ')';
 
     if (this.arguments_.length === 0) {
-      const dd = makeDropdown();
-      this.appendDummyInput('TOP_LINE').appendField('new ').appendField(dd, 'CONSTRUCTOR_CLASS');
-      // Force the field to the correct value after appending.
-      const field = this.getField('CONSTRUCTOR_CLASS');
-      if (field && value) {
-        const origOpts = field.getOptions.bind(field);
-        field.getOptions = () => { const opts = origOpts(); if (!opts.find(([, v]) => v === value)) opts.push([className + '()', value]); return opts; };
-        field.setValue(value);
-        field.getOptions = origOpts;
-      }
+      // ── No-arg constructor ────────────────────────────────────────────
+      this.appendDummyInput('TOP_LINE')
+        .appendField('new ')
+        .appendField(makeDropdown(), 'CONSTRUCTOR_CLASS');
+      forceSetField(this.getField('CONSTRUCTOR_CLASS'), value, displayLabel);
     } else {
-      // First arg connector on the same row as 'new ClassName('.
+      // ── Constructor with args ─────────────────────────────────────────
       const firstArg = this.arguments_[0];
-      const dd = makeDropdown();
       this.appendValueInput('ARG_' + firstArg)
         .appendField('new ')
-        .appendField(dd, 'CONSTRUCTOR_CLASS')
+        .appendField(makeDropdown(), 'CONSTRUCTOR_CLASS')
         .appendField('( ' + firstArg + (this.arguments_.length > 1 ? ' ,' : ' )'));
-      // Force the field to the correct value.
-      const field = this.getField('CONSTRUCTOR_CLASS');
-      if (field && value) {
-        const origOpts = field.getOptions.bind(field);
-        field.getOptions = () => { const opts = origOpts(); if (!opts.find(([, v]) => v === value)) opts.push([className + '(' + this.arguments_.join(', ') + ')', value]); return opts; };
-        field.setValue(value);
-        field.getOptions = origOpts;
-      }
+      forceSetField(this.getField('CONSTRUCTOR_CLASS'), value, displayLabel);
+
       // Restore first-arg connection.
-      if (savedConns[firstArg] && savedConns[firstArg].getSourceBlock && savedConns[firstArg].getSourceBlock().workspace) {
+      if (savedConns[firstArg]?.getSourceBlock?.()?.workspace) {
         this.getInput('ARG_' + firstArg).connection.connect(savedConns[firstArg]);
       }
+
       // Remaining args below, right-aligned.
       for (let j = 1; j < this.arguments_.length; j++) {
         const arg = this.arguments_[j];
         this.appendValueInput('ARG_' + arg)
           .setAlign(Blockly.inputs.Align.RIGHT)
           .appendField(arg + (j + 1 === this.arguments_.length ? ' )' : ' ,'));
-        if (savedConns[arg] && savedConns[arg].getSourceBlock && savedConns[arg].getSourceBlock().workspace) {
+        if (savedConns[arg]?.getSourceBlock?.()?.workspace) {
           this.getInput('ARG_' + arg).connection.connect(savedConns[arg]);
         }
       }

--- a/custom-generator-codelab/src/blocks/java_variable_blocks.js
+++ b/custom-generator-codelab/src/blocks/java_variable_blocks.js
@@ -322,6 +322,48 @@ function makeCallBlock(callType, name, argNames) {
   return b;
 }
 
+/**
+ * Appends call blocks for every method defined by the parent class into xmlList.
+ * Only called when a java_extends block is present in the workspace.
+ */
+function _appendParentClassMethods(workspace, xmlList) {
+  const extendsBlocks = workspace.getBlocksByType('java_extends', false);
+  if (!extendsBlocks.length) return;
+  const parentClass = extendsBlocks[0].getFieldValue('PARENT_CLASS');
+  if (!parentClass || parentClass === 'NONE') return;
+  const allMethods = LocalStorageManager.getAllMethods();
+  const parentMethods = allMethods[parentClass] || [];
+  if (!parentMethods.length) return;
+  xmlList.push(makeLabel('Methoden von ' + parentClass + ' (Elternklasse)'));
+  for (const method of parentMethods) {
+    let callType;
+    if (method.isStatic) {
+      callType = method.hasReturn ? 'java_static_method_call_return' : 'java_static_method_call_noreturn';
+    } else {
+      callType = method.hasReturn ? 'java_method_call_return' : 'java_method_call_noreturn';
+    }
+    const callBlock = makeCallBlock(callType, method.name, method.arguments || []);
+    callBlock.setAttribute('gap', '8');
+    xmlList.push(callBlock);
+  }
+}
+
+/**
+ * Appends inline param-get blocks for argNames when the Parameter category is hidden.
+ */
+function _appendInlineParams(workspace, xmlList, argNames) {
+  for (let pi = 0; pi < argNames.length; pi++) {
+    const paramVar = workspace.getVariable(argNames[pi], VAR_TYPE_PARAM);
+    if (paramVar) {
+      const getBlock = Blockly.utils.xml.createElement('block');
+      getBlock.setAttribute('type', 'java_param_get');
+      getBlock.setAttribute('gap', pi === argNames.length - 1 ? '20' : '4');
+      getBlock.appendChild(varField(paramVar));
+      xmlList.push(getBlock);
+    }
+  }
+}
+
 export function methodFlyoutCategory(workspace) {
   const methodConfig = ToolboxConfigManager.getSubcategoryConfig('Methoden');
   const showGroup = (name) => !methodConfig || methodConfig.get(name) !== false;
@@ -337,16 +379,7 @@ export function methodFlyoutCategory(workspace) {
       const argNames = ctrBlock.arguments_ || [];
       if (argNames.length === 0) continue;
       xmlList.push(makeLabel('Konstruktor(' + argNames.join(', ') + ')'));
-      for (let pi = 0; pi < argNames.length; pi++) {
-        const paramVar = workspace.getVariable(argNames[pi], VAR_TYPE_PARAM);
-        if (paramVar) {
-          const getBlock = Blockly.utils.xml.createElement('block');
-          getBlock.setAttribute('type', 'java_param_get');
-          getBlock.setAttribute('gap', pi === argNames.length - 1 ? '20' : '4');
-          getBlock.appendChild(varField(paramVar));
-          xmlList.push(getBlock);
-        }
-      }
+      _appendInlineParams(workspace, xmlList, argNames);
     }
   }
 
@@ -380,45 +413,15 @@ export function methodFlyoutCategory(workspace) {
         xmlList.push(callBlock);
 
         // Inline param-get blocks when Parameter category is hidden.
-        if (showParamsInline) {
-          for (let pi = 0; pi < argNames.length; pi++) {
-            const paramVar = workspace.getVariable(argNames[pi], VAR_TYPE_PARAM);
-            if (paramVar) {
-              const getBlock = Blockly.utils.xml.createElement('block');
-              getBlock.setAttribute('type', 'java_param_get');
-              getBlock.setAttribute('gap', pi === argNames.length - 1 ? '20' : '4');
-              getBlock.appendChild(varField(paramVar));
-              xmlList.push(getBlock);
-            }
-          }
-        }
+        if (showParamsInline) _appendInlineParams(workspace, xmlList, argNames);
       }
     }
   }
 
   // ── Super-class methods ───────────────────────────────────────────────────
   // If there is a java_extends block, also expose call blocks for every
-  // method defined in the parent class (stored in LocalStorage during
-  // parent-class code generation).
-  const extendsBlocks = workspace.getBlocksByType('java_extends', false);
-  if (extendsBlocks.length > 0) {
-    const parentClass = extendsBlocks[0].getFieldValue('PARENT_CLASS');
-    if (parentClass && parentClass !== 'NONE') {
-      const allMethods = LocalStorageManager.getAllMethods();
-      const parentMethods = allMethods[parentClass] || [];
-      if (parentMethods.length > 0) {
-        xmlList.push(makeLabel('Methoden von ' + parentClass + ' (Elternklasse)'));
-        for (const method of parentMethods) {
-          const callType = method.isStatic
-            ? (method.hasReturn ? 'java_static_method_call_return' : 'java_static_method_call_noreturn')
-            : (method.hasReturn ? 'java_method_call_return'        : 'java_method_call_noreturn');
-          const callBlock = makeCallBlock(callType, method.name, method.arguments || []);
-          callBlock.setAttribute('gap', '8');
-          xmlList.push(callBlock);
-        }
-      }
-    }
-  }
+  // method defined in the parent class.
+  _appendParentClassMethods(workspace, xmlList);
 
   return xmlList;
 }
@@ -609,7 +612,7 @@ export function staticAttrFlyoutCategory(workspace) {
 // ─────────────────────────────────────────────────────────────────────────────
 export function allAttrFlyoutCategory(workspace) {
   const attrConfig = ToolboxConfigManager.getSubcategoryConfig('Attribute');
-  const show = (name) => !attrConfig || attrConfig.get(name) !== false;
+  const show = (name) => attrConfig?.get(name) !== false;
 
   const sections = [];
 
@@ -633,7 +636,7 @@ export function allAttrFlyoutCategory(workspace) {
 // ─────────────────────────────────────────────────────────────────────────────
 export function allVariablesFlyoutCategory(workspace) {
   const varConfig = ToolboxConfigManager.getSubcategoryConfig('Variablen');
-  const show = (name) => !varConfig || varConfig.get(name) !== false;
+  const show = (name) => varConfig?.get(name) !== false;
 
   const sections = [];
 

--- a/custom-generator-codelab/src/blocks/java_variable_blocks.js
+++ b/custom-generator-codelab/src/blocks/java_variable_blocks.js
@@ -15,6 +15,7 @@
 
 import * as Blockly from 'blockly/core';
 import { ToolboxConfigManager } from '../utils/ToolboxConfigManager.js';
+import LocalStorageManager from '../utils/LocalStorageManager.js';
 
 // ─── Type & colour constants ────────────────────────────────────────────────
 // These type strings are the Blockly variable-type tags used to separate the
@@ -326,6 +327,28 @@ export function methodFlyoutCategory(workspace) {
   const showGroup = (name) => !methodConfig || methodConfig.get(name) !== false;
 
   const xmlList = [];
+
+  // ── Constructor parameters ──────────────────────────────────────────────
+  // Scan all defconstructor blocks and add param-get blocks so students can
+  // read constructor parameters inside their method bodies.
+  const ctrBlocks = workspace.getBlocksByType('defconstructor', true);
+  for (const ctrBlock of ctrBlocks) {
+    const argNames = ctrBlock.arguments_ || [];
+    if (argNames.length > 0) {
+      xmlList.push(makeLabel('Konstruktor-Parameter'));
+      for (let pi = 0; pi < argNames.length; pi++) {
+        const paramVar = workspace.getVariable(argNames[pi], VAR_TYPE_PARAM);
+        if (paramVar) {
+          const getBlock = Blockly.utils.xml.createElement('block');
+          getBlock.setAttribute('type', 'java_param_get');
+          getBlock.setAttribute('gap', pi === argNames.length - 1 ? '20' : '4');
+          getBlock.appendChild(varField(paramVar));
+          xmlList.push(getBlock);
+        }
+      }
+    }
+  }
+
   const GROUP_NAMES = ['Objekt-Methoden', 'Klassen-Methoden'];
   for (let i = 0; i < METHOD_GROUPS.length; i++) {
     const groupName = GROUP_NAMES[i];
@@ -370,6 +393,31 @@ export function methodFlyoutCategory(workspace) {
       }
     }
   }
+
+  // ── Super-class methods ───────────────────────────────────────────────────
+  // If there is a java_extends block, also expose call blocks for every
+  // method defined in the parent class (stored in LocalStorage during
+  // parent-class code generation).
+  const extendsBlocks = workspace.getBlocksByType('java_extends', false);
+  if (extendsBlocks.length > 0) {
+    const parentClass = extendsBlocks[0].getFieldValue('PARENT_CLASS');
+    if (parentClass && parentClass !== 'NONE') {
+      const allMethods = LocalStorageManager.getAllMethods();
+      const parentMethods = allMethods[parentClass] || [];
+      if (parentMethods.length > 0) {
+        xmlList.push(makeLabel('Methoden von ' + parentClass + ' (Elternklasse)'));
+        for (const method of parentMethods) {
+          const callType = method.isStatic
+            ? (method.hasReturn ? 'java_static_method_call_return' : 'java_static_method_call_noreturn')
+            : (method.hasReturn ? 'java_method_call_return'        : 'java_method_call_noreturn');
+          const callBlock = makeCallBlock(callType, method.name, method.arguments || []);
+          callBlock.setAttribute('gap', '8');
+          xmlList.push(callBlock);
+        }
+      }
+    }
+  }
+
   return xmlList;
 }
 

--- a/custom-generator-codelab/src/blocks/java_variable_blocks.js
+++ b/custom-generator-codelab/src/blocks/java_variable_blocks.js
@@ -323,19 +323,20 @@ function makeCallBlock(callType, name, argNames) {
 }
 
 export function methodFlyoutCategory(workspace) {
-  const methodConfig    = ToolboxConfigManager.getSubcategoryConfig('Methoden');
+  const methodConfig = ToolboxConfigManager.getSubcategoryConfig('Methoden');
   const showGroup = (name) => !methodConfig || methodConfig.get(name) !== false;
+  // When the dedicated Parameter category is hidden, show params inline here.
+  const showParamsInline = !ToolboxConfigManager.isCategoryActive('Parameter');
 
   const xmlList = [];
 
-  // ── Constructor parameters ──────────────────────────────────────────────
-  // Scan all defconstructor blocks and add param-get blocks so students can
-  // read constructor parameters inside their method bodies.
-  const ctrBlocks = workspace.getBlocksByType('defconstructor', true);
-  for (const ctrBlock of ctrBlocks) {
-    const argNames = ctrBlock.arguments_ || [];
-    if (argNames.length > 0) {
-      xmlList.push(makeLabel('Konstruktor-Parameter'));
+  // ── Constructor parameters (inline fallback) ───────────────────────────
+  if (showParamsInline) {
+    const ctrBlocks = workspace.getBlocksByType('defconstructor', true);
+    for (const ctrBlock of ctrBlocks) {
+      const argNames = ctrBlock.arguments_ || [];
+      if (argNames.length === 0) continue;
+      xmlList.push(makeLabel('Konstruktor(' + argNames.join(', ') + ')'));
       for (let pi = 0; pi < argNames.length; pi++) {
         const paramVar = workspace.getVariable(argNames[pi], VAR_TYPE_PARAM);
         if (paramVar) {
@@ -366,28 +367,29 @@ export function methodFlyoutCategory(workspace) {
       if (showDef(def.type)) xmlList.push(makeBlockTemplate(def.type));
     }
 
-    // Call blocks + param-get blocks – only for active def types.
+    // Call blocks – only for active def types.
     for (const { defType, callType } of group.calls) {
       if (!showDef(defType)) continue;
       for (const block of workspace.getBlocksByType(defType, true)) {
         const name = block.getFieldValue('NAME') || 'unbekannt';
         const argNames = block.arguments_ || [];
 
-        // Call block — small gap so params feel attached.
+        // Call block.
         const callBlock = makeCallBlock(callType, name, argNames);
-        callBlock.setAttribute('gap', argNames.length > 0 ? '4' : '16');
+        callBlock.setAttribute('gap', showParamsInline && argNames.length > 0 ? '4' : '16');
         xmlList.push(callBlock);
 
-        // Param-get blocks directly below — tight gap between them,
-        // larger gap after the last one to separate from the next method.
-        for (let pi = 0; pi < argNames.length; pi++) {
-          const paramVar = workspace.getVariable(argNames[pi], VAR_TYPE_PARAM);
-          if (paramVar) {
-            const getBlock = Blockly.utils.xml.createElement('block');
-            getBlock.setAttribute('type', 'java_param_get');
-            getBlock.setAttribute('gap', pi === argNames.length - 1 ? '20' : '4');
-            getBlock.appendChild(varField(paramVar));
-            xmlList.push(getBlock);
+        // Inline param-get blocks when Parameter category is hidden.
+        if (showParamsInline) {
+          for (let pi = 0; pi < argNames.length; pi++) {
+            const paramVar = workspace.getVariable(argNames[pi], VAR_TYPE_PARAM);
+            if (paramVar) {
+              const getBlock = Blockly.utils.xml.createElement('block');
+              getBlock.setAttribute('type', 'java_param_get');
+              getBlock.setAttribute('gap', pi === argNames.length - 1 ? '20' : '4');
+              getBlock.appendChild(varField(paramVar));
+              xmlList.push(getBlock);
+            }
           }
         }
       }
@@ -465,13 +467,58 @@ export function normalAttrFlyoutCategory(workspace) {
 export function paramFlyoutCategory(workspace) {
   const xmlList = [];
   // No create-button: params are created via the method block mutator.
-  for (const variable of workspace.getVariablesOfType(VAR_TYPE_PARAM)) {
+  // Group param blocks by their source method/constructor with a heading label.
+
+  // Helper to push a label
+  function pushLabel(text, gap = '8') {
+    const lbl = Blockly.utils.xml.createElement('label');
+    lbl.setAttribute('text', text);
+    lbl.setAttribute('gap', gap);
+    xmlList.push(lbl);
+  }
+
+  // Helper to push a param-get block for a variable
+  function pushParamBlock(variable, isLast) {
     const getBlock = Blockly.utils.xml.createElement('block');
     getBlock.setAttribute('type', 'java_param_get');
-    getBlock.setAttribute('gap', '8');
+    getBlock.setAttribute('gap', isLast ? '16' : '4');
     getBlock.appendChild(varField(variable));
     xmlList.push(getBlock);
   }
+
+  // ── Constructor parameters ──────────────────────────────────────────────
+  const ctrBlocks = workspace.getBlocksByType('defconstructor', true);
+  for (const ctrBlock of ctrBlocks) {
+    const argNames = ctrBlock.arguments_ || [];
+    if (argNames.length === 0) continue;
+    pushLabel('Konstruktor(' + argNames.join(', ') + ')');
+    for (let i = 0; i < argNames.length; i++) {
+      const paramVar = workspace.getVariable(argNames[i], VAR_TYPE_PARAM);
+      if (paramVar) pushParamBlock(paramVar, i === argNames.length - 1);
+    }
+  }
+
+  // ── Method parameters ───────────────────────────────────────────────────
+  const METHOD_BLOCK_TYPES = [
+    'java_method_noreturn',
+    'java_method_return',
+    'java_static_method_noreturn',
+    'java_static_method_return',
+  ];
+
+  for (const blockType of METHOD_BLOCK_TYPES) {
+    for (const methodBlock of workspace.getBlocksByType(blockType, true)) {
+      const argNames = methodBlock.arguments_ || [];
+      if (argNames.length === 0) continue;
+      const methodName = methodBlock.getFieldValue('NAME') || 'unbekannt';
+      pushLabel(methodName + '(' + argNames.join(', ') + ')');
+      for (let i = 0; i < argNames.length; i++) {
+        const paramVar = workspace.getVariable(argNames[i], VAR_TYPE_PARAM);
+        if (paramVar) pushParamBlock(paramVar, i === argNames.length - 1);
+      }
+    }
+  }
+
   return xmlList;
 }
 
@@ -558,41 +605,41 @@ export function staticAttrFlyoutCategory(workspace) {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Combined flyout: Attribute + Stat. Attribute + Lok. Variablen in one panel
+// Combined flyout: Instanz-Attribute + Klassen-Attribute in one panel
+// ─────────────────────────────────────────────────────────────────────────────
+export function allAttrFlyoutCategory(workspace) {
+  const attrConfig = ToolboxConfigManager.getSubcategoryConfig('Attribute');
+  const show = (name) => !attrConfig || attrConfig.get(name) !== false;
+
+  const sections = [];
+
+  if (show('Instanz-Attribute')) {
+    sections.push(
+      ...normalAttrFlyoutCategory(workspace),
+    );
+  }
+
+  if (show('Klassen-Attribute')) {
+    sections.push(
+      ...staticAttrFlyoutCategory(workspace),
+    );
+  }
+
+  return sections;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Combined flyout: Lok. Variablen only (attributes moved to own category)
 // ─────────────────────────────────────────────────────────────────────────────
 export function allVariablesFlyoutCategory(workspace) {
   const varConfig = ToolboxConfigManager.getSubcategoryConfig('Variablen');
   const show = (name) => !varConfig || varConfig.get(name) !== false;
 
-  function sectionLabel(text, gap = '8') {
-    const lbl = Blockly.utils.xml.createElement('label');
-    lbl.setAttribute('text', text);
-    lbl.setAttribute('gap', gap);
-    return lbl;
-  }
-
   const sections = [];
 
   if (show('Lokale Variablen')) {
     sections.push(
-      sectionLabel('Lokale Variable'),
       ...localVarFlyoutCategory(workspace),
-    );
-  }
-
-  if (show('Attribute')) {
-    sections.push(
-      sectionLabel('Instanz-Attribute'),
-      sectionLabel('(1 Wert pro Objekt)'),
-      ...normalAttrFlyoutCategory(workspace),
-    );
-  }
-
-  if (show('Statische Attribute')) {
-    sections.push(
-      sectionLabel('Klassen-Attribute'),
-      sectionLabel('(1 Wert pro Klasse)'),
-      ...staticAttrFlyoutCategory(workspace),
     );
   }
 

--- a/custom-generator-codelab/src/generators/javascript/constructors.js
+++ b/custom-generator-codelab/src/generators/javascript/constructors.js
@@ -19,6 +19,19 @@ import LocalStorageManager from '../../utils/LocalStorageManager.js';
 
 
 
+/**
+ * Resolves the Java type for the j-th constructor parameter.
+ * Falls back through callsite hints, super-call hints, then 'Object'.
+ */
+function _resolveParamType(j, vars, className, superHints, variables, ws) {
+  const rawType = getVariableType(ws, vars[j].getId(), true);
+  if (rawType !== 'var') return rawType;
+  const callsiteHints = LocalStorageManager.getConstructorCallsiteHints(className);
+  if (callsiteHints?.[j] != null) return callsiteHints[j];
+  if (superHints && variables[j] && superHints[variables[j]]) return superHints[variables[j]];
+  return 'Object';
+}
+
 export function defconstructor(block, generator) {
   const className = getClassName();
   LocalStorageManager.storeConstructors(className, block);
@@ -61,22 +74,8 @@ export function defconstructor(block, generator) {
     let paramTypes = [];
     // Fetch any super-call type hints stored by sub-class workspaces.
     const superHints = LocalStorageManager.getSuperCallTypeHints(className);
-    for(let j = 0; j < vars.length; j++)
-    {
-      paramTypes[j] = getVariableType(ws, vars[j].getId(), true);
-      if(paramTypes[j] === 'var')
-      {
-        // 1. Try callsite hints stored when another class called new ClassName(...).
-        const callsiteHints = LocalStorageManager.getConstructorCallsiteHints(className);
-        if (callsiteHints && callsiteHints[j] != null) {
-          paramTypes[j] = callsiteHints[j];
-        // 2. Try super-call hints left by sub-class java_super_call generators.
-        } else if (superHints && variables[j] && superHints[variables[j]]) {
-          paramTypes[j] = superHints[variables[j]];
-        } else {
-          paramTypes[j] = 'Object';
-        }
-      }
+    for(let j = 0; j < vars.length; j++) {
+      paramTypes[j] = _resolveParamType(j, vars, className, superHints, variables, ws);
     }
     console.log("variables: " + variables);
     for (let i = 0; i < variables.length; i++) {
@@ -107,10 +106,10 @@ export function callconstructor(block, generator) {
   // Iterate all inputs that have a value connection (ARG inputs).
   // The TOP_LINE input may be a DummyInput or a ValueInput (when the first arg
   // is inlined on the same row as the dropdown), so we check by connection.
-  for (let inputNr = 0; inputNr < block.inputList.length; inputNr++) {
-    if (block.inputList[inputNr].connection != null) {
-      const paramId = block.inputList[inputNr].name;
-      const inputBlock = block.inputList[inputNr].connection.targetBlock();
+  for (const input of block.inputList) {
+    if (input.connection != null) {
+      const paramId = input.name;
+      const inputBlock = input.connection.targetBlock();
       if (inputBlock != null) {
         args.push(generator.valueToCode(block, paramId, Order.NONE));
       } else {
@@ -132,43 +131,43 @@ export function java_extends(block, generator) {
   return null;
 };
 
+/**
+ * Collects inferred Java types for each super() argument from the block
+ * connections, returning a map of paramName → Java type.
+ */
+function _collectSuperCallTypeHints(argNames, block, ws) {
+  const typeHints = {};
+  for (let i = 0; i < argNames.length; i++) {
+    const argBlock = block.getInput('ARG' + i)?.connection?.targetBlock();
+    if (argBlock) {
+      const t = resolveArgBlockType(argBlock, ws);
+      if (t && t !== TYPES.UNKNOWN) typeHints[argNames[i]] = t;
+    }
+  }
+  return typeHints;
+}
+
 // ── java_super_call – super-constructor call ──────────────────────────────
 export function java_super_call(block, generator) {
   const args = [];
   const argNames = block.argNames_ || [];
 
   // ── Collect type hints for the super-class constructor parameters ─────
-  // Hints are stored keyed by the *sub-class* name so they are replaced on
-  // every regeneration (clearConstructors clears them before generateCode).
   const ws = Blockly.getMainWorkspace();
-  const extendsBlocks = ws ? ws.getBlocksByType('java_extends', false) : [];
+  const extendsBlocks = ws?.getBlocksByType('java_extends', false) ?? [];
   const parentClass = extendsBlocks.length > 0
     ? extendsBlocks[0].getFieldValue('PARENT_CLASS')
     : null;
   if (parentClass && parentClass !== 'NONE') {
     const subClass = getClassName();
-    const typeHints = {};
-    for (let i = 0; i < argNames.length; i++) {
-      const inp = block.getInput('ARG' + i);
-      if (inp && inp.connection && inp.connection.targetBlock()) {
-        const argBlock = inp.connection.targetBlock();
-        const t = resolveArgBlockType(argBlock, ws);
-        if (t && t !== TYPES.UNKNOWN) {
-          typeHints[argNames[i]] = t;
-        }
-      }
-    }
+    const typeHints = _collectSuperCallTypeHints(argNames, block, ws);
     // Always write (even if empty) so a previously non-empty entry is cleared.
     LocalStorageManager.storeSuperCallTypeHints(subClass, parentClass, typeHints);
   }
 
   for (let i = 0; i < argNames.length; i++) {
-    const inp = block.getInput('ARG' + i);
-    if (inp && inp.connection && inp.connection.targetBlock()) {
-      args.push(generator.valueToCode(block, 'ARG' + i, Order.NONE) || 'null');
-    } else {
-      args.push('null');
-    }
+    const argBlock = block.getInput('ARG' + i)?.connection?.targetBlock();
+    args.push(argBlock ? generator.valueToCode(block, 'ARG' + i, Order.NONE) || 'null' : 'null');
   }
   return 'super(' + args.join(', ') + ');\n';
 };

--- a/custom-generator-codelab/src/generators/javascript/constructors.js
+++ b/custom-generator-codelab/src/generators/javascript/constructors.js
@@ -104,15 +104,17 @@ export function callconstructor(block, generator) {
   const funcName = sepIdx >= 0 ? dropdownValue.slice(0, sepIdx) : getClassName();
 
   const args = [];
-  // inputList[0] is the TOP_LINE dummy input; argument inputs start at index 1.
-  for (let inputNr = 1; inputNr < block.inputList.length; inputNr++) {
+  // Iterate all inputs that have a value connection (ARG inputs).
+  // The TOP_LINE input may be a DummyInput or a ValueInput (when the first arg
+  // is inlined on the same row as the dropdown), so we check by connection.
+  for (let inputNr = 0; inputNr < block.inputList.length; inputNr++) {
     if (block.inputList[inputNr].connection != null) {
       const paramId = block.inputList[inputNr].name;
       const inputBlock = block.inputList[inputNr].connection.targetBlock();
       if (inputBlock != null) {
-        args[inputNr - 1] = generator.valueToCode(block, paramId, Order.NONE);
+        args.push(generator.valueToCode(block, paramId, Order.NONE));
       } else {
-        args[inputNr - 1] = 'null';
+        args.push('null');
       }
     }
   }

--- a/custom-generator-codelab/src/generators/javascript/constructors.js
+++ b/custom-generator-codelab/src/generators/javascript/constructors.js
@@ -11,7 +11,7 @@
 // Former goog.module ID: Blockly.JavaScript.procedures
 
 import { javascriptGenerator } from 'blockly/javascript.js';
-import {getType, getVariableType, Order, getClassName, setExtendsClass, TYPES} from './javascript_generator.js';
+import {getType, getVariableType, resolveArgBlockType, Order, getClassName, setExtendsClass, TYPES} from './javascript_generator.js';
 import * as Blockly from "blockly";
 import LocalStorageManager from '../../utils/LocalStorageManager.js';
 
@@ -59,12 +59,23 @@ export function defconstructor(block, generator) {
   if(variables !== null) {
     let vars = block.getVarModels();
     let paramTypes = [];
+    // Fetch any super-call type hints stored by sub-class workspaces.
+    const superHints = LocalStorageManager.getSuperCallTypeHints(className);
     for(let j = 0; j < vars.length; j++)
     {
       paramTypes[j] = getVariableType(ws, vars[j].getId(), true);
       if(paramTypes[j] === 'var')
       {
-        paramTypes[j] = 'Object';
+        // 1. Try callsite hints stored when another class called new ClassName(...).
+        const callsiteHints = LocalStorageManager.getConstructorCallsiteHints(className);
+        if (callsiteHints && callsiteHints[j] != null) {
+          paramTypes[j] = callsiteHints[j];
+        // 2. Try super-call hints left by sub-class java_super_call generators.
+        } else if (superHints && variables[j] && superHints[variables[j]]) {
+          paramTypes[j] = superHints[variables[j]];
+        } else {
+          paramTypes[j] = 'Object';
+        }
       }
     }
     console.log("variables: " + variables);
@@ -123,6 +134,32 @@ export function java_extends(block, generator) {
 export function java_super_call(block, generator) {
   const args = [];
   const argNames = block.argNames_ || [];
+
+  // ── Collect type hints for the super-class constructor parameters ─────
+  // Hints are stored keyed by the *sub-class* name so they are replaced on
+  // every regeneration (clearConstructors clears them before generateCode).
+  const ws = Blockly.getMainWorkspace();
+  const extendsBlocks = ws ? ws.getBlocksByType('java_extends', false) : [];
+  const parentClass = extendsBlocks.length > 0
+    ? extendsBlocks[0].getFieldValue('PARENT_CLASS')
+    : null;
+  if (parentClass && parentClass !== 'NONE') {
+    const subClass = getClassName();
+    const typeHints = {};
+    for (let i = 0; i < argNames.length; i++) {
+      const inp = block.getInput('ARG' + i);
+      if (inp && inp.connection && inp.connection.targetBlock()) {
+        const argBlock = inp.connection.targetBlock();
+        const t = resolveArgBlockType(argBlock, ws);
+        if (t && t !== TYPES.UNKNOWN) {
+          typeHints[argNames[i]] = t;
+        }
+      }
+    }
+    // Always write (even if empty) so a previously non-empty entry is cleared.
+    LocalStorageManager.storeSuperCallTypeHints(subClass, parentClass, typeHints);
+  }
+
   for (let i = 0; i < argNames.length; i++) {
     const inp = block.getInput('ARG' + i);
     if (inp && inp.connection && inp.connection.targetBlock()) {

--- a/custom-generator-codelab/src/generators/javascript/constructors.js
+++ b/custom-generator-codelab/src/generators/javascript/constructors.js
@@ -11,7 +11,7 @@
 // Former goog.module ID: Blockly.JavaScript.procedures
 
 import { javascriptGenerator } from 'blockly/javascript.js';
-import {getType, getVariableType, Order, getClassName, TYPES} from './javascript_generator.js';
+import {getType, getVariableType, Order, getClassName, setExtendsClass, TYPES} from './javascript_generator.js';
 import * as Blockly from "blockly";
 import LocalStorageManager from '../../utils/LocalStorageManager.js';
 
@@ -108,4 +108,28 @@ export function callconstructor(block, generator) {
 
   const code = 'new ' + funcName + '(' + args.join(', ') + ')';
   return [code, Order.FUNCTION_CALL];
+};
+
+// ── java_extends – inheritance declaration ────────────────────────────────
+export function java_extends(block, generator) {
+  const parentClass = block.getFieldValue('PARENT_CLASS');
+  if (parentClass && parentClass !== 'NONE') {
+    setExtendsClass(parentClass);
+  }
+  return null;
+};
+
+// ── java_super_call – super-constructor call ──────────────────────────────
+export function java_super_call(block, generator) {
+  const args = [];
+  const argNames = block.argNames_ || [];
+  for (let i = 0; i < argNames.length; i++) {
+    const inp = block.getInput('ARG' + i);
+    if (inp && inp.connection && inp.connection.targetBlock()) {
+      args.push(generator.valueToCode(block, 'ARG' + i, Order.NONE) || 'null');
+    } else {
+      args.push('null');
+    }
+  }
+  return 'super(' + args.join(', ') + ');\n';
 };

--- a/custom-generator-codelab/src/generators/javascript/java_methods.js
+++ b/custom-generator-codelab/src/generators/javascript/java_methods.js
@@ -14,8 +14,9 @@
  * the existing getVariableType helper.
  */
 
-import {getType, getVariableType, Order, TYPES} from './javascript_generator.js';
+import {getType, getVariableType, Order, getClassName, TYPES} from './javascript_generator.js';
 import * as Blockly from 'blockly';
+import LocalStorageManager from '../../utils/LocalStorageManager.js';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Shared helper: build the full method body code.
@@ -103,6 +104,7 @@ export function java_static_method_noreturn(block, generator) {
   const funcName = block.getFieldValue('NAME') || 'unbekannt';
   const code = buildMethodCode(block, generator, true);
   generator.definitions_['%static_' + funcName] = code;
+  LocalStorageManager.storeMethods(getClassName(), { name: funcName, arguments: block.arguments_ || [], isStatic: true, hasReturn: false });
   return null;
 }
 
@@ -110,6 +112,7 @@ export function java_static_method_return(block, generator) {
   const funcName = block.getFieldValue('NAME') || 'unbekannt';
   const code = buildMethodCode(block, generator, true);
   generator.definitions_['%static_' + funcName] = code;
+  LocalStorageManager.storeMethods(getClassName(), { name: funcName, arguments: block.arguments_ || [], isStatic: true, hasReturn: true });
   return null;
 }
 
@@ -117,6 +120,7 @@ export function java_method_noreturn(block, generator) {
   const funcName = block.getFieldValue('NAME') || 'unbekannt';
   const code = buildMethodCode(block, generator, false);
   generator.definitions_['%method_' + funcName] = code;
+  LocalStorageManager.storeMethods(getClassName(), { name: funcName, arguments: block.arguments_ || [], isStatic: false, hasReturn: false });
   return null;
 }
 
@@ -124,6 +128,7 @@ export function java_method_return(block, generator) {
   const funcName = block.getFieldValue('NAME') || 'unbekannt';
   const code = buildMethodCode(block, generator, false);
   generator.definitions_['%method_' + funcName] = code;
+  LocalStorageManager.storeMethods(getClassName(), { name: funcName, arguments: block.arguments_ || [], isStatic: false, hasReturn: true });
   return null;
 }
 

--- a/custom-generator-codelab/src/generators/javascript/java_methods.js
+++ b/custom-generator-codelab/src/generators/javascript/java_methods.js
@@ -147,14 +147,14 @@ function buildCallArgs(block, generator) {
 export function java_static_method_call_noreturn(block, generator) {
   const name = block.getFieldValue('NAME');
   const args = buildCallArgs(block, generator);
-  return `${name}(${args});
+  return `${getClassName()}.${name}(${args});
 `;
 }
 
 export function java_static_method_call_return(block, generator) {
   const name = block.getFieldValue('NAME');
   const args = buildCallArgs(block, generator);
-  return [`${name}(${args})`, Order.ATOMIC];
+  return [`${getClassName()}.${name}(${args})`, Order.ATOMIC];
 }
 
 export function java_method_call_noreturn(block, generator) {

--- a/custom-generator-codelab/src/generators/javascript/javascript_generator.js
+++ b/custom-generator-codelab/src/generators/javascript/javascript_generator.js
@@ -258,11 +258,136 @@ export function adjustStaticName(name) {
   return name;
 }
 
+// ── Polymorphism / inheritance helpers ───────────────────────────────────────
+
+/**
+ * Returns the direct parent class name for `className` by reading:
+ *  1. The super-call type hints store (populated when a sub-class is generated).
+ *  2. The class's saved workspace JSON (looking for a java_extends block),
+ *     so the hierarchy is available even before the sub-class has been generated.
+ */
+function getClassParent(className) {
+  // 1. Super-call type hints (fastest, populated at generation time).
+  const raw = globalThis.localStorage?.getItem(LocalStorageManager.SUPER_CALL_TYPE_HINTS_KEY);
+  if (raw) {
+    const store = JSON.parse(raw) || {};
+    const entry = store[className];
+    if (entry && entry.parentClass) return entry.parentClass;
+  }
+  // 2. Read the class's saved workspace JSON and look for a java_extends block.
+  //    This works even when the sub-class has never been "generated" yet.
+  try {
+    const workspaceRaw = LocalStorageManager.loadWorkspace(className);
+    if (workspaceRaw) {
+      const parsed = JSON.parse(workspaceRaw);
+      const topBlocks = parsed?.blocks?.blocks ?? [];
+      for (const block of topBlocks) {
+        if (block.type === 'java_extends' &&
+            block.fields?.PARENT_CLASS &&
+            block.fields.PARENT_CLASS !== 'NONE') {
+          return block.fields.PARENT_CLASS;
+        }
+      }
+    }
+  } catch (_) { /* ignore parse errors */ }
+  return null;
+}
+
+/**
+ * Returns the ancestor chain for a class (including itself), ordered from the
+ * class itself up to the root.
+ * e.g.  Child → ["Child", "Super"]  (if Super has no recorded parent)
+ */
+function getAncestorChain(className, maxDepth = 30) {
+  const chain = [];
+  let current = className;
+  const seen = new Set();
+  while (current && !seen.has(current) && chain.length < maxDepth) {
+    chain.push(current);
+    seen.add(current);
+    current = getClassParent(current);
+  }
+  return chain;
+}
+
+/**
+ * Given a non-empty list of Java type strings that may represent class names,
+ * returns their lowest common ancestor (LCA) in the recorded inheritance
+ * hierarchy.  Falls back to 'Object' when no shared ancestor is found.
+ *
+ * Only meaningful when every element looks like a class name (not a Java
+ * primitive such as int/boolean/String).
+ */
+function findCommonSupertype(types) {
+  if (types.length === 0) return TYPES.UNKNOWN;
+  if (types.length === 1) return types[0];
+  if (types.every(t => t === types[0])) return types[0];
+
+  // Build ancestor chains for each type.
+  const chains = types.map(t => getAncestorChain(t));
+
+  // Search breadth-first across ALL chains (not just chains[0]) so that we
+  // find the LCA even when the first type's chain is incomplete.
+  // We iterate by depth level: at depth 0 we check each chain's direct class,
+  // at depth 1 its parent, etc.
+  const maxLen = Math.max(...chains.map(c => c.length));
+  for (let depth = 0; depth < maxLen; depth++) {
+    for (const chain of chains) {
+      if (depth < chain.length) {
+        const candidate = chain[depth];
+        if (chains.every(c => c.includes(candidate))) {
+          return candidate;
+        }
+      }
+    }
+  }
+  return 'Object';
+}
+
+/** Primitive / built-in Java types that are NOT class names. */
+const PRIMITIVE_TYPES = new Set(['int', 'double', 'boolean', 'String', 'Object', 'List<Object>', 'forint', 'void']);
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Hard call-budget for getVariableType.
+ *
+ * Every entry into _getVariableTypeImpl decrements this counter.
+ * It is reset to MAX_VAR_TYPE_CALLS at the start of each *fresh* (non-nested)
+ * call to getVariableType so unrelated type lookups each get a full budget,
+ * while any runaway chain of mutual variable references is capped globally.
+ *
+ * 100 calls is far more than any realistic workspace needs (a project with
+ * 20 variables each queried via 3 heuristics = ~60 calls), but small enough
+ * to stop tight cycles within a few milliseconds.
+ */
+const MAX_VAR_TYPE_CALLS = 100;
+let _varTypeBudget = MAX_VAR_TYPE_CALLS;
+let _varTypeDepth = 0;   // nesting depth – 0 means we are in an outer call
+
 //returns variable type by searching for usage context.
 export function getVariableType(workSpace, varId, useCompares, recursionDeepness = 10) {
-  if(recursionDeepness==10){
-    //console.log("Get Variable (try: " + (11-recursionDeepness) + "): " + varId);
+  // Reset the budget once per top-level call so every fresh query gets a
+  // full allowance while still bounding any cycle reachable from it.
+  const isOuterCall = (_varTypeDepth === 0);
+  if (isOuterCall) {
+    _varTypeBudget = MAX_VAR_TYPE_CALLS;
   }
+
+  if (_varTypeBudget <= 0) {
+    return 'var';
+  }
+
+  _varTypeBudget--;
+  _varTypeDepth++;
+  try {
+    return _getVariableTypeImpl(workSpace, varId, useCompares, recursionDeepness);
+  } finally {
+    _varTypeDepth--;
+  }
+}
+
+function _getVariableTypeImpl(workSpace, varId, useCompares, recursionDeepness) {
 
   //let varName = CodeGenerator.getVariableName(varId);
 
@@ -290,26 +415,29 @@ export function getVariableType(workSpace, varId, useCompares, recursionDeepness
     ...workSpace.getBlocksByType('java_local_var_set', true),
   ];
   blocks = setterBlocks;
+  // Collect every concrete type assigned to this variable so we can
+  // determine the correct declared type even under polymorphism (e.g. when a
+  // variable is assigned both a Child and a Super instance we must declare it
+  // as Super, not just whatever the first assignment happened to be).
+  const collectedSetterTypes = [];
   for (let i = 0; i < blocks.length; i++) {
     if(blocks[i].getFieldValue('VAR') === varId) {
       if (blocks[i].getInputTargetBlock('VALUE') != null) {
         const valueBlock = blocks[i].getInputTargetBlock('VALUE');
         //control if it's set to another variable- if yes, use its type.
-        const GETTER_BLOCK_TYPES = new Set([
-          'variables_get', 'java_local_var_get', 'java_static_attr_get',
-          'java_normal_attr_get', 'java_param_get',
-        ]);
         if(GETTER_BLOCK_TYPES.has(valueBlock.type)) {
           if(valueBlock.getFieldValue('VAR') !== varId) {
             varsAssignedToThis[c] = valueBlock.getFieldValue('VAR');
             c++;
           }
         }
+        // Determine the type of the assigned value.
+        let blockVarType = 'var';
         // For callconstructor, extract the actual class name from the dropdown.
         if (valueBlock.type === 'callconstructor') {
           const dropdownValue = valueBlock.getFieldValue('CONSTRUCTOR_CLASS') || '';
           const sepIdx = dropdownValue.indexOf(':::');
-          varType = sepIdx >= 0 ? dropdownValue.slice(0, sepIdx) : TYPES.CLASS;
+          blockVarType = sepIdx >= 0 ? dropdownValue.slice(0, sepIdx) : TYPES.CLASS;
         } else if (valueBlock.type === 'java_static_method_call_return'
                 || valueBlock.type === 'java_method_call_return') {
           // Look up the matching method definition to determine its return type.
@@ -321,18 +449,31 @@ export function getVariableType(workSpace, varId, useCompares, recursionDeepness
               const returnBlock = defBlock.getInputTargetBlock('RETURN');
               if (returnBlock) {
                 const t = getType(returnBlock.type);
-                if (t !== TYPES.UNKNOWN) { varType = t; break; }
+                if (t !== TYPES.UNKNOWN) { blockVarType = t; break; }
               }
             }
           }
         } else {
-          varType = getType(valueBlock.type);
+          blockVarType = getType(valueBlock.type);
+        }
+        if (blockVarType !== 'var') {
+          collectedSetterTypes.push(blockVarType);
         }
       }
-      if(varType !== 'var') {
-        return varType;
-      }
     }
+  }
+
+  if (collectedSetterTypes.length > 0) {
+    // Fast path: all assignments have the same type.
+    if (collectedSetterTypes.every(t => t === collectedSetterTypes[0])) {
+      return collectedSetterTypes[0];
+    }
+    // Polymorphic case: multiple distinct class types → find their LCA.
+    if (collectedSetterTypes.every(t => !PRIMITIVE_TYPES.has(t))) {
+      return findCommonSupertype(collectedSetterTypes);
+    }
+    // Mixed primitive/class types – fall back to first resolved type (legacy).
+    return collectedSetterTypes[0];
   }
 
   
@@ -376,7 +517,10 @@ export function getVariableType(workSpace, varId, useCompares, recursionDeepness
         if (gb.getParent().type === 'logic_compare') {
           if(useCompares)
           {
-            return compareControl(workSpace, gb.getParent(), varId)
+            // Pass recursionDeepness - 1 to prevent infinite recursion;
+            // compareControl used to call getVariableType without a depth
+            // argument which silently reset it to 10 on every call.
+            return compareControl(workSpace, gb.getParent(), varId, recursionDeepness - 1);
           }
         }
         //control if it is used to set a variable. if yes, use that type
@@ -534,10 +678,12 @@ export function getVariableType(workSpace, varId, useCompares, recursionDeepness
 
 //takes a logic_compare block and checks what is compared
 //only to be used by the getVarType function
-export function compareControl(workSpace, block, varId) {
+export function compareControl(workSpace, block, varId, recursionDeepness = 9) {
   if(block.type !== 'logic_compare') {
     return null;
   }
+
+  if (recursionDeepness <= 0) return 'var';
 
   let left = block.getInputTargetBlock('A');
   let right = block.getInputTargetBlock('B');
@@ -559,13 +705,13 @@ export function compareControl(workSpace, block, varId) {
 
   if(leftIsVar && left.getFieldValue('VAR') === varId) {
     if(rightIsVar) {
-      return getVariableType(workSpace, right.getFieldValue('VAR'), false);
+      return getVariableType(workSpace, right.getFieldValue('VAR'), false, recursionDeepness);
     }
     return getType(right.type);
   }
   else if(rightIsVar && right.getFieldValue('VAR') === varId) {
     if(leftIsVar) {
-      return getVariableType(workSpace, left.getFieldValue('VAR'), false);
+      return getVariableType(workSpace, left.getFieldValue('VAR'), false, recursionDeepness);
     }
     return getType(left.type);
   }

--- a/custom-generator-codelab/src/generators/javascript/javascript_generator.js
+++ b/custom-generator-codelab/src/generators/javascript/javascript_generator.js
@@ -189,65 +189,82 @@ export function getType(var_type) {
  *
  * @param {Blockly.Block} argBlock
  * @param {Blockly.Workspace} workspace
+/**
+ * Resolves the class name from a callconstructor block's dropdown value.
+ * @param {Blockly.Block} argBlock
+ * @returns {string}
+ */
+function _resolveConstructorArgType(argBlock) {
+  const dv = argBlock.getFieldValue('CONSTRUCTOR_CLASS') || '';
+  const sep = dv.indexOf(':::');
+  return (sep >= 0 ? dv.slice(0, sep) : '') || TYPES.UNKNOWN;
+}
+
+/**
+ * Resolves the return type of a method-call block by scanning def blocks.
+ * @param {Blockly.Block} argBlock
+ * @param {Blockly.Workspace} workspace
+ * @returns {string}
+ */
+function _resolveMethodCallType(argBlock, workspace) {
+  const methodName = argBlock.getFieldValue('NAME');
+  const defType = argBlock.type === 'java_static_method_call_return'
+    ? 'java_static_method_return' : 'java_method_return';
+  for (const defBlock of workspace.getBlocksByType(defType, true)) {
+    if (defBlock.getFieldValue('NAME') === methodName) {
+      const returnBlock = defBlock.getInputTargetBlock('RETURN');
+      if (returnBlock) {
+        const t = resolveArgBlockType(returnBlock, workspace);
+        if (t !== TYPES.UNKNOWN) return t;
+      }
+    }
+  }
+  return TYPES.UNKNOWN;
+}
+
+/**
+ * Resolves the type of a variable-getter block, falling back to cross-workspace
+ * callsite hints stored in LocalStorage.
+ * @param {Blockly.Block} argBlock
+ * @param {Blockly.Workspace} workspace
+ * @returns {string}
+ */
+function _resolveGetterType(argBlock, workspace) {
+  const varId = argBlock.getFieldValue('VAR');
+  if (!varId) return TYPES.UNKNOWN;
+  const t = getVariableType(workspace, varId, false);
+  if (t && t !== 'var' && t !== TYPES.UNKNOWN) return t;
+  // Check callsite hints for constructor parameters from other classes.
+  const ctorBlocks = workspace.getBlocksByType('defconstructor', false);
+  for (const ctorBlock of ctorBlocks) {
+    const varModels = ctorBlock.getVarModels?.() ?? [];
+    const idx = varModels.findIndex(v => v.getId() === varId);
+    if (idx >= 0) {
+      const callsiteHints = LocalStorageManager.getConstructorCallsiteHints(getClassName());
+      if (callsiteHints?.[idx] != null) return callsiteHints[idx];
+      break;
+    }
+  }
+  return TYPES.UNKNOWN;
+}
+
+/** All block types that represent a variable read (any kind). */
+const GETTER_ARG_TYPES = new Set([
+  'variables_get', 'java_local_var_get', 'java_static_attr_get',
+  'java_normal_attr_get', 'java_param_get',
+]);
+
+/**
  * @returns {string} Java type string, or TYPES.UNKNOWN
  */
 export function resolveArgBlockType(argBlock, workspace) {
   if (!argBlock) return TYPES.UNKNOWN;
-
-  // callconstructor – extract actual class name from the dropdown
-  if (argBlock.type === 'callconstructor') {
-    const dv = argBlock.getFieldValue('CONSTRUCTOR_CLASS') || '';
-    const sep = dv.indexOf(':::');
-    return (sep >= 0 ? dv.slice(0, sep) : '') || TYPES.UNKNOWN;
-  }
-
-  // method call with return value – look up matching def block's return type
+  if (argBlock.type === 'callconstructor') return _resolveConstructorArgType(argBlock);
   if (argBlock.type === 'java_method_call_return' ||
       argBlock.type === 'java_static_method_call_return') {
-    const methodName = argBlock.getFieldValue('NAME');
-    const defType = argBlock.type === 'java_static_method_call_return'
-      ? 'java_static_method_return' : 'java_method_return';
-    for (const defBlock of workspace.getBlocksByType(defType, true)) {
-      if (defBlock.getFieldValue('NAME') === methodName) {
-        const returnBlock = defBlock.getInputTargetBlock('RETURN');
-        if (returnBlock) {
-          const t = resolveArgBlockType(returnBlock, workspace);
-          if (t !== TYPES.UNKNOWN) return t;
-        }
-      }
-    }
-    return TYPES.UNKNOWN;
+    return _resolveMethodCallType(argBlock, workspace);
   }
-
-  // variable getter – try getVariableType first, then callsite hints
-  const GETTER_TYPES = new Set([
-    'variables_get', 'java_local_var_get', 'java_static_attr_get',
-    'java_normal_attr_get', 'java_param_get',
-  ]);
-  if (GETTER_TYPES.has(argBlock.type)) {
-    const varId = argBlock.getFieldValue('VAR');
-    if (varId) {
-      const t = getVariableType(workspace, varId, false);
-      if (t && t !== 'var' && t !== TYPES.UNKNOWN) return t;
-
-      // Type is unknown in the local workspace (e.g. the variable is a
-      // constructor parameter whose call site is in another class's workspace).
-      // Check callsite hints stored during that other class's generation.
-      const ctorBlocks = workspace.getBlocksByType('defconstructor', false);
-      for (const ctorBlock of ctorBlocks) {
-        const varModels = ctorBlock.getVarModels ? ctorBlock.getVarModels() : [];
-        const idx = varModels.findIndex(v => v.getId() === varId);
-        if (idx >= 0) {
-          const callsiteHints = LocalStorageManager.getConstructorCallsiteHints(getClassName());
-          if (callsiteHints && callsiteHints[idx] != null) return callsiteHints[idx];
-          break;
-        }
-      }
-    }
-    return TYPES.UNKNOWN;
-  }
-
-  // literal / math / boolean / etc.
+  if (GETTER_ARG_TYPES.has(argBlock.type)) return _resolveGetterType(argBlock, workspace);
   return getType(argBlock.type);
 }
 
@@ -272,7 +289,7 @@ function getClassParent(className) {
   if (raw) {
     const store = JSON.parse(raw) || {};
     const entry = store[className];
-    if (entry && entry.parentClass) return entry.parentClass;
+    if (entry?.parentClass) return entry.parentClass;
   }
   // 2. Read the class's saved workspace JSON and look for a java_extends block.
   //    This works even when the sub-class has never been "generated" yet.
@@ -289,7 +306,11 @@ function getClassParent(className) {
         }
       }
     }
-  } catch (_) { /* ignore parse errors */ }
+  } catch (e) {
+    // Intentionally ignored — parse errors in saved workspaces should not crash
+    // the inheritance hierarchy lookup.
+    console.debug('[Blockly2Java] Could not parse workspace for parent lookup:', e);
+  }
   return null;
 }
 
@@ -387,121 +408,86 @@ export function getVariableType(workSpace, varId, useCompares, recursionDeepness
   }
 }
 
-function _getVariableTypeImpl(workSpace, varId, useCompares, recursionDeepness) {
+// ─── Type-inference sub-routines ────────────────────────────────────────────
 
-  //let varName = CodeGenerator.getVariableName(varId);
-
-  //if the variable is used for a forLoop, it's an int
-  let blocks = workSpace.getBlocksByType('controls_for',true);
-  for (let i = 0; i < blocks.length; i++) {
-    if(blocks[i].getFieldValue('VAR') === varId) {
-      return TYPES.FORINT;
-    }
+/** Checks whether varId is used as a for-loop counter. */
+function _searchForLoopVar(workSpace, varId) {
+  for (const b of workSpace.getBlocksByType('controls_for', true)) {
+    if (b.getFieldValue('VAR') === varId) return TYPES.FORINT;
   }
+  return null;
+}
 
-  let varType = 'var'
-  const varsAssignedToThis = [];
-  let c = 0;
-  //search if the variable is ever set (covers all setter block kinds)
-  // All block types that represent a variable read (any kind)
-  const GETTER_BLOCK_TYPES = new Set([
-    'variables_get', 'java_local_var_get', 'java_static_attr_get',
-    'java_normal_attr_get', 'java_param_get',
-  ]);
-  const setterBlocks = [
+/**
+ * Scans all setter blocks and collects every concrete Java type assigned to
+ * varId.  Also populates varsAssignedToThis with the ids of variables whose
+ * value is copied into varId.
+ */
+function _collectSetterTypes(workSpace, varId, GETTER_TYPES, varsAssignedToThis) {
+  const types = [];
+  const blocks = [
     ...workSpace.getBlocksByType('variables_set', true),
     ...workSpace.getBlocksByType('java_normal_attr_set', true),
     ...workSpace.getBlocksByType('java_static_attr_set', true),
     ...workSpace.getBlocksByType('java_local_var_set', true),
   ];
-  blocks = setterBlocks;
-  // Collect every concrete type assigned to this variable so we can
-  // determine the correct declared type even under polymorphism (e.g. when a
-  // variable is assigned both a Child and a Super instance we must declare it
-  // as Super, not just whatever the first assignment happened to be).
-  const collectedSetterTypes = [];
-  for (let i = 0; i < blocks.length; i++) {
-    if(blocks[i].getFieldValue('VAR') === varId) {
-      if (blocks[i].getInputTargetBlock('VALUE') != null) {
-        const valueBlock = blocks[i].getInputTargetBlock('VALUE');
-        //control if it's set to another variable- if yes, use its type.
-        if(GETTER_BLOCK_TYPES.has(valueBlock.type)) {
-          if(valueBlock.getFieldValue('VAR') !== varId) {
-            varsAssignedToThis[c] = valueBlock.getFieldValue('VAR');
-            c++;
-          }
-        }
-        // Determine the type of the assigned value.
-        let blockVarType = 'var';
-        // For callconstructor, extract the actual class name from the dropdown.
-        if (valueBlock.type === 'callconstructor') {
-          const dropdownValue = valueBlock.getFieldValue('CONSTRUCTOR_CLASS') || '';
-          const sepIdx = dropdownValue.indexOf(':::');
-          blockVarType = sepIdx >= 0 ? dropdownValue.slice(0, sepIdx) : TYPES.CLASS;
-        } else if (valueBlock.type === 'java_static_method_call_return'
-                || valueBlock.type === 'java_method_call_return') {
-          // Look up the matching method definition to determine its return type.
-          const methodName = valueBlock.getFieldValue('NAME');
-          const defType = valueBlock.type === 'java_static_method_call_return'
-            ? 'java_static_method_return' : 'java_method_return';
-          for (const defBlock of workSpace.getBlocksByType(defType, true)) {
-            if (defBlock.getFieldValue('NAME') === methodName) {
-              const returnBlock = defBlock.getInputTargetBlock('RETURN');
-              if (returnBlock) {
-                const t = getType(returnBlock.type);
-                if (t !== TYPES.UNKNOWN) { blockVarType = t; break; }
-              }
-            }
-          }
-        } else {
-          blockVarType = getType(valueBlock.type);
-        }
-        if (blockVarType !== 'var') {
-          collectedSetterTypes.push(blockVarType);
-        }
+  for (const block of blocks) {
+    if (block.getFieldValue('VAR') !== varId) continue;
+    const valueBlock = block.getInputTargetBlock('VALUE');
+    if (!valueBlock) continue;
+    if (GETTER_TYPES.has(valueBlock.type) && valueBlock.getFieldValue('VAR') !== varId) {
+      varsAssignedToThis.push(valueBlock.getFieldValue('VAR'));
+    }
+    types.push(_resolveAssignedBlockType(workSpace, valueBlock));
+  }
+  return types.filter(t => t !== 'var');
+}
+
+/** Resolves the Java type of a value block used in an assignment. */
+function _resolveAssignedBlockType(workSpace, valueBlock) {
+  if (valueBlock.type === 'callconstructor') {
+    const dv = valueBlock.getFieldValue('CONSTRUCTOR_CLASS') || '';
+    const si = dv.indexOf(':::');
+    return si >= 0 ? dv.slice(0, si) : TYPES.CLASS;
+  }
+  if (valueBlock.type === 'java_static_method_call_return' ||
+      valueBlock.type === 'java_method_call_return') {
+    const mn = valueBlock.getFieldValue('NAME');
+    const dt = valueBlock.type === 'java_static_method_call_return'
+      ? 'java_static_method_return' : 'java_method_return';
+    for (const def of workSpace.getBlocksByType(dt, true)) {
+      if (def.getFieldValue('NAME') === mn) {
+        const rb = def.getInputTargetBlock('RETURN');
+        if (rb) { const t = getType(rb.type); if (t !== TYPES.UNKNOWN) return t; }
       }
     }
+    return 'var';
   }
+  return getType(valueBlock.type);
+}
 
-  if (collectedSetterTypes.length > 0) {
-    // Fast path: all assignments have the same type.
-    if (collectedSetterTypes.every(t => t === collectedSetterTypes[0])) {
-      return collectedSetterTypes[0];
-    }
-    // Polymorphic case: multiple distinct class types → find their LCA.
-    if (collectedSetterTypes.every(t => !PRIMITIVE_TYPES.has(t))) {
-      return findCommonSupertype(collectedSetterTypes);
-    }
-    // Mixed primitive/class types – fall back to first resolved type (legacy).
-    return collectedSetterTypes[0];
-  }
-
-  
-  //search if the variable is ever set
-  blocks = workSpace.getBlocksByType('math_change',true);
-  for (let i = 0; i < blocks.length; i++) {
-    //console.log(blocks[i]);
-    //console.log(blocks[i].getFieldValue('VAR'));
-
-    if(blocks[i].getFieldValue('VAR') === varId) {
-        const inputList = blocks[i].inputList;
-        let blockType = 'math_number';
-        if(inputList.length > 0) {
-          let blockType = inputList[0].connection.targetBlock().type;
-        }
-        //console.log(blockType);
-        varType = getType(blockType);
-      if(varType !== 'var') {
-        return varType;
-      }
+/** Checks math_change blocks; returns type or null. */
+function _searchMathChangeVar(workSpace, varId) {
+  for (const block of workSpace.getBlocksByType('math_change', true)) {
+    if (block.getFieldValue('VAR') === varId) {
+      const inputList = block.inputList;
+      const blockType = inputList.length > 0 ? inputList[0].connection.targetBlock().type : 'math_number';
+      const t = getType(blockType);
+      if (t !== 'var') return t;
     }
   }
+  return null;
+}
 
-
-  const varsAssignedFromThis = [];
-  c = 0;
-
-  //search if the variable is ever used (covers all getter block kinds)
+/**
+ * Searches all getter blocks for context-clues about varId's type.
+ * Populates varsAssignedFromThis when the variable is used to set another.
+ * Returns a non-'var' type string when found, otherwise 'var'.
+ */
+function _searchGetterContextVar(workSpace, varId, useCompares, varsAssignedFromThis, recursionDeepness) {
+  const SETTER_TYPES = new Set([
+    'variables_set', 'java_static_attr_set', 'java_normal_attr_set', 'java_local_var_set',
+  ]);
   const getterBlocks = [
     ...workSpace.getBlocksByType('variables_get', true),
     ...workSpace.getBlocksByType('java_static_attr_get', true),
@@ -509,102 +495,62 @@ function _getVariableTypeImpl(workSpace, varId, useCompares, recursionDeepness) 
     ...workSpace.getBlocksByType('java_normal_attr_get', true),
     ...workSpace.getBlocksByType('java_param_get', true),
   ];
-  for (let i = 0; i < getterBlocks.length; i++) {
-    const gb = getterBlocks[i];
-    if(gb.getFieldValue('VAR') === varId) {
-      if (gb.getParent() != null) {
-        //logic compares need to be handled differently if they are a parent Block
-        if (gb.getParent().type === 'logic_compare') {
-          if(useCompares)
-          {
-            // Pass recursionDeepness - 1 to prevent infinite recursion;
-            // compareControl used to call getVariableType without a depth
-            // argument which silently reset it to 10 on every call.
-            return compareControl(workSpace, gb.getParent(), varId, recursionDeepness - 1);
-          }
-        }
-        //control if it is used to set a variable. if yes, use that type
-        if (gb.getParent().type === 'variables_set'
-          || gb.getParent().type === 'java_static_attr_set'
-          || gb.getParent().type === 'java_normal_attr_set'
-          || gb.getParent().type === 'java_local_var_set') {
-          if(gb.getParent().getFieldValue('VAR') !== varId) {
-            varsAssignedFromThis[c] = gb.getParent().getFieldValue('VAR');
-            c++;
-          }
-        }
-        varType = getType(gb.getParent().type);
+  let varType = 'var';
+  for (const gb of getterBlocks) {
+    if (gb.getFieldValue('VAR') !== varId) continue;
+    const parent = gb.getParent();
+    if (parent) {
+      if (parent.type === 'logic_compare' && useCompares) {
+        return compareControl(workSpace, parent, varId, recursionDeepness - 1);
       }
-      if(varType !== 'var') {
-        return varType;
+      if (SETTER_TYPES.has(parent.type) && parent.getFieldValue('VAR') !== varId) {
+        varsAssignedFromThis.push(parent.getFieldValue('VAR'));
+      }
+      varType = getType(parent.type);
+    }
+    if (varType !== 'var') return varType;
+  }
+  return varType;
+}
+
+/** Checks callconstructor inputs to see if varId is one of them. Returns type or null. */
+function _searchCallconstructorInput(workSpace, varId) {
+  for (const b of workSpace.getBlocksByType('callconstructor', true)) {
+    for (let n = 1; n < b.inputList.length; n++) {
+      if (b.inputList[n].connection != null && b.inputList[n].name === varId) {
+        const ib = b.inputList[n].connection.targetBlock();
+        if (ib != null) return getType(ib.type);
       }
     }
   }
+  return null;
+}
 
-  // Search for the variable in the callconstructor blocks
-  blocks = workSpace.getBlocksByType('callconstructor',true);
-
-  for (let blockNr = 0; blockNr < blocks.length; blockNr++) 
-  {
-    let b = blocks[blockNr];
-
-    for (let inputNr = 1; inputNr < b.inputList.length; inputNr++) 
-    {
-      if(b.inputList[inputNr].connection != null) {
-        let paramId = b.inputList[inputNr].name;
-        //console.log("ParamId: "+paramId);
-
-        if(paramId === varId) {
-          let inputBlock = b.inputList[inputNr].connection.targetBlock();
-          //console.log(inputBlock);
-          if(inputBlock != null) {
-            //console.log(inputBlock.type);
-            return getType(inputBlock.type);
-          }
+/** Checks built-in procedure call blocks. Returns type or null. */
+function _searchProcedureCallInput(workSpace, varId) {
+  const returnBlocks = workSpace.getBlocksByType('procedures_callreturn', true);
+  const noReturnBlocks = workSpace.getBlocksByType('procedures_callnoreturn', true);
+  const blocks = (returnBlocks && noReturnBlocks) ? returnBlocks.concat(noReturnBlocks)
+    : (returnBlocks || noReturnBlocks || []);
+  for (const b of blocks) {
+    for (let n = 1; n < b.inputList.length; n++) {
+      if (b.inputList[n].connection) {
+        if (b.getVarModels()[n - 1]?.getId() === varId) {
+          const ib = b.inputList[n].connection.targetBlock();
+          if (ib) return getType(ib.type);
         }
       }
     }
   }
+  return null;
+}
 
-  // Search for the variable in the callconstructor blocks
-
-  let returnBlocks = workSpace.getBlocksByType('procedures_callreturn',true);
-  let noReturnBlocks = workSpace.getBlocksByType('procedures_callnoreturn',true);
-
-  if(!noReturnBlocks) {
-    blocks = returnBlocks;
-  }
-  else if(!returnBlocks) {
-    blocks = noReturnBlocks;
-  }
-  else { 
-    blocks = returnBlocks.concat(noReturnBlocks);
-  }
-
-  for (let blockNr = 0; blockNr < blocks.length; blockNr++) 
-  {
-    let b = blocks[blockNr];
-    for (let inputNr = 1; inputNr < b.inputList.length; inputNr++) 
-    {
-      if(b.inputList[inputNr].connection) {
-        let paramId = b.getVarModels()[inputNr-1].getId()
-        if(paramId === varId) {
-          let inputBlock = b.inputList[inputNr].connection.targetBlock();
-          if(inputBlock) {
-            return getType(inputBlock.type);
-          }
-        }
-      }
-    }
-  }
-
-
-  
-
-
-
-  // Search for the variable in custom method / static-method call blocks.
-  // This allows parameter types to be inferred from call-site arguments.
+/** Checks custom method/static-method call blocks. Returns type or null. */
+function _searchMethodCallInput(workSpace, varId, useCompares, recursionDeepness) {
+  const GETTER_TYPES2 = new Set([
+    'variables_get', 'java_local_var_get', 'java_static_attr_get',
+    'java_normal_attr_get', 'java_param_get',
+  ]);
   const methodDefCallPairs = [
     ['java_method_noreturn',        'java_method_call_noreturn'],
     ['java_method_return',          'java_method_call_return'],
@@ -612,68 +558,94 @@ function _getVariableTypeImpl(workSpace, varId, useCompares, recursionDeepness) 
     ['java_static_method_return',   'java_static_method_call_return'],
   ];
   for (const [defType, callType] of methodDefCallPairs) {
-    for (const defBlock of workSpace.getBlocksByType(defType, true)) {
-      const varModels = defBlock.getVarModels ? defBlock.getVarModels() : [];
-      const numParams = defBlock.arguments_ ? defBlock.arguments_.length : 0;
-      for (let argIdx = 0; argIdx < numParams; argIdx++) {
-        if (varModels[argIdx] && varModels[argIdx].getId() === varId) {
-          const methodName = defBlock.getFieldValue('NAME');
-          for (const callBlock of workSpace.getBlocksByType(callType, true)) {
-            if (callBlock.getFieldValue('NAME') === methodName) {
-              const argBlock = callBlock.getInputTargetBlock('ARG' + argIdx);
-              if (argBlock) {
-                const t = getType(argBlock.type);
-                if (t !== TYPES.UNKNOWN) return t;
-                // Recurse if the argument is itself a variable getter
-                if (recursionDeepness > 0) {
-                  const GETTER_BLOCK_TYPES2 = new Set([
-                    'variables_get', 'java_local_var_get', 'java_static_attr_get',
-                    'java_normal_attr_get', 'java_param_get',
-                  ]);
-                  if (GETTER_BLOCK_TYPES2.has(argBlock.type)) {
-                    const argVarId = argBlock.getFieldValue('VAR');
-                    if (argVarId && argVarId !== varId) {
-                      const t2 = getVariableType(workSpace, argVarId, useCompares, recursionDeepness - 1);
-                      if (t2 !== TYPES.UNKNOWN && t2 !== 'var') return t2;
-                    }
-                  }
-                }
-              }
-            }
+    const result = _searchMethodDefCallPair(workSpace, varId, defType, callType, GETTER_TYPES2, useCompares, recursionDeepness);
+    if (result) return result;
+  }
+  return null;
+}
+
+/** Helper for one def/call pair inside _searchMethodCallInput. */
+function _searchMethodDefCallPair(workSpace, varId, defType, callType, GETTER_TYPES2, useCompares, recursionDeepness) {
+  for (const defBlock of workSpace.getBlocksByType(defType, true)) {
+    const varModels = defBlock.getVarModels?.() ?? [];
+    const numParams = defBlock.arguments_?.length ?? 0;
+    for (let argIdx = 0; argIdx < numParams; argIdx++) {
+      if (varModels[argIdx]?.getId() !== varId) continue;
+      const methodName = defBlock.getFieldValue('NAME');
+      for (const callBlock of workSpace.getBlocksByType(callType, true)) {
+        if (callBlock.getFieldValue('NAME') !== methodName) continue;
+        const argBlock = callBlock.getInputTargetBlock('ARG' + argIdx);
+        if (!argBlock) continue;
+        const t = getType(argBlock.type);
+        if (t !== TYPES.UNKNOWN) return t;
+        if (recursionDeepness > 0 && GETTER_TYPES2.has(argBlock.type)) {
+          const argVarId = argBlock.getFieldValue('VAR');
+          if (argVarId && argVarId !== varId) {
+            const t2 = getVariableType(workSpace, argVarId, useCompares, recursionDeepness - 1);
+            if (t2 !== TYPES.UNKNOWN && t2 !== 'var') return t2;
           }
         }
       }
     }
   }
+  return null;
+}
 
-  if(recursionDeepness <= 0) {
-    console.log("Recursion limit reached while searching for variable type");
-    return varType;
+/** Checks assigned-variable ids recursively. Returns type string or 'var'. */
+function _resolveByAssignedVars(workSpace, vars, recursionDeepness) {
+  for (const assignedId of vars) {
+    const t = getVariableType(workSpace, assignedId, true, recursionDeepness - 1);
+    if (t === 'forint') return 'int';
+    if (t !== 'var') return t;
   }
-  for (let i = 0;i < varsAssignedToThis.length; i++)
-  {
-    varType = getVariableType(workSpace, varsAssignedToThis[i], true, recursionDeepness-1);
-    //alert(varId + '  To this: ' + varType);
-    if(varType === 'forint') {
-      return 'int';
-    }
-    if(varType !== 'var') {
-      return varType;
-    }
+  return 'var';
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+
+function _getVariableTypeImpl(workSpace, varId, useCompares, recursionDeepness) {
+  const forLoopType = _searchForLoopVar(workSpace, varId);
+  if (forLoopType) return forLoopType;
+
+  const GETTER_BLOCK_TYPES = new Set([
+    'variables_get', 'java_local_var_get', 'java_static_attr_get',
+    'java_normal_attr_get', 'java_param_get',
+  ]);
+  const varsAssignedToThis = [];
+  const setterTypes = _collectSetterTypes(workSpace, varId, GETTER_BLOCK_TYPES, varsAssignedToThis);
+
+  if (setterTypes.length > 0) {
+    if (setterTypes.every(t => t === setterTypes[0])) return setterTypes[0];
+    if (setterTypes.every(t => !PRIMITIVE_TYPES.has(t))) return findCommonSupertype(setterTypes);
+    return setterTypes[0];
   }
-  for (let i = 0;i < varsAssignedFromThis.length; i++)
-  {
-    varType = getVariableType(workSpace, varsAssignedFromThis[i], true, recursionDeepness-1);
-    //alert(varId + '  From this: ' + varType);
-    if(varType === 'forint') {
-      return 'int';
-    }
-    if(varType !== 'var') {
-      return varType;
-    }
+
+  const mathType = _searchMathChangeVar(workSpace, varId);
+  if (mathType) return mathType;
+
+  const varsAssignedFromThis = [];
+  const getterType = _searchGetterContextVar(workSpace, varId, useCompares, varsAssignedFromThis, recursionDeepness);
+  if (getterType !== 'var') return getterType;
+
+  const ctrType = _searchCallconstructorInput(workSpace, varId);
+  if (ctrType) return ctrType;
+
+  const procType = _searchProcedureCallInput(workSpace, varId);
+  if (procType) return procType;
+
+  const methodType = _searchMethodCallInput(workSpace, varId, useCompares, recursionDeepness);
+  if (methodType) return methodType;
+
+  if (recursionDeepness <= 0) {
+    console.log('Recursion limit reached while searching for variable type');
+    return 'var';
   }
-  return varType;
-};
+
+  const fromAssigned = _resolveByAssignedVars(workSpace, varsAssignedToThis, recursionDeepness);
+  if (fromAssigned !== 'var') return fromAssigned;
+
+  return _resolveByAssignedVars(workSpace, varsAssignedFromThis, recursionDeepness);
+}
 
 
 //takes a logic_compare block and checks what is compared
@@ -1001,7 +973,7 @@ export class JavascriptGenerator extends Blockly.CodeGenerator {
           const _conn = callBlock.inputList[_n].connection;
           const _argBlock = _conn ? _conn.targetBlock() : null;
           const _t = resolveArgBlockType(_argBlock, workspace);
-          _types.push(_t !== TYPES.UNKNOWN ? _t : null);
+          _types.push(_t === TYPES.UNKNOWN ? null : _t);
         }
         if (_types.some(_t => _t !== null)) {
           _callHintsByCallee[_calledClass] = _types;

--- a/custom-generator-codelab/src/generators/javascript/javascript_generator.js
+++ b/custom-generator-codelab/src/generators/javascript/javascript_generator.js
@@ -30,6 +30,16 @@ export function getClassName() {
   return className;
 }
 
+let extendsClass = '';
+
+export function setExtendsClass(name) {
+  extendsClass = name;
+}
+
+export function getExtendsClass() {
+  return extendsClass;
+}
+
 export var ctrCount = 0;
 
 /**
@@ -571,6 +581,9 @@ export class JavascriptGenerator extends Blockly.CodeGenerator {
 
     // Reset per-generation tracking for local variable first-declaration.
     this.declaredLocalVarIds_ = new Set();
+
+    // Reset extends-class so that a removed java_extends block takes effect.
+    extendsClass = '';
 
     if (!this.nameDB_) {
       this.nameDB_ = new Blockly.Names(this.RESERVED_WORDS_);

--- a/custom-generator-codelab/src/generators/javascript/javascript_generator.js
+++ b/custom-generator-codelab/src/generators/javascript/javascript_generator.js
@@ -12,6 +12,7 @@
 // Former goog.module ID: Blockly.JavaScript
 
 import * as Blockly from 'blockly/core';
+import LocalStorageManager from '../../utils/LocalStorageManager.js';
 //\import { block } from 'blockly/core/tooltip';
 //import { block } from 'blockly/core/tooltip';
 // import type {Block} from '../../core/block.js';
@@ -174,6 +175,81 @@ export function getType(var_type) {
   return TYPES.UNKNOWN;
 }
 
+
+/**
+ * Resolves the Java type of a block connected as an argument value.
+ *
+ * Unlike the simple `getType(block.type)`, this handles:
+ *  - callconstructor → extracts the actual class name from the dropdown
+ *  - method call return blocks → looks up the matching def block
+ *  - variable getters → delegates to getVariableType, then falls back to
+ *    cross-workspace constructor-callsite hints stored in LocalStorage
+ *
+ * Exported so other generators can use it without circular imports.
+ *
+ * @param {Blockly.Block} argBlock
+ * @param {Blockly.Workspace} workspace
+ * @returns {string} Java type string, or TYPES.UNKNOWN
+ */
+export function resolveArgBlockType(argBlock, workspace) {
+  if (!argBlock) return TYPES.UNKNOWN;
+
+  // callconstructor – extract actual class name from the dropdown
+  if (argBlock.type === 'callconstructor') {
+    const dv = argBlock.getFieldValue('CONSTRUCTOR_CLASS') || '';
+    const sep = dv.indexOf(':::');
+    return (sep >= 0 ? dv.slice(0, sep) : '') || TYPES.UNKNOWN;
+  }
+
+  // method call with return value – look up matching def block's return type
+  if (argBlock.type === 'java_method_call_return' ||
+      argBlock.type === 'java_static_method_call_return') {
+    const methodName = argBlock.getFieldValue('NAME');
+    const defType = argBlock.type === 'java_static_method_call_return'
+      ? 'java_static_method_return' : 'java_method_return';
+    for (const defBlock of workspace.getBlocksByType(defType, true)) {
+      if (defBlock.getFieldValue('NAME') === methodName) {
+        const returnBlock = defBlock.getInputTargetBlock('RETURN');
+        if (returnBlock) {
+          const t = resolveArgBlockType(returnBlock, workspace);
+          if (t !== TYPES.UNKNOWN) return t;
+        }
+      }
+    }
+    return TYPES.UNKNOWN;
+  }
+
+  // variable getter – try getVariableType first, then callsite hints
+  const GETTER_TYPES = new Set([
+    'variables_get', 'java_local_var_get', 'java_static_attr_get',
+    'java_normal_attr_get', 'java_param_get',
+  ]);
+  if (GETTER_TYPES.has(argBlock.type)) {
+    const varId = argBlock.getFieldValue('VAR');
+    if (varId) {
+      const t = getVariableType(workspace, varId, false);
+      if (t && t !== 'var' && t !== TYPES.UNKNOWN) return t;
+
+      // Type is unknown in the local workspace (e.g. the variable is a
+      // constructor parameter whose call site is in another class's workspace).
+      // Check callsite hints stored during that other class's generation.
+      const ctorBlocks = workspace.getBlocksByType('defconstructor', false);
+      for (const ctorBlock of ctorBlocks) {
+        const varModels = ctorBlock.getVarModels ? ctorBlock.getVarModels() : [];
+        const idx = varModels.findIndex(v => v.getId() === varId);
+        if (idx >= 0) {
+          const callsiteHints = LocalStorageManager.getConstructorCallsiteHints(getClassName());
+          if (callsiteHints && callsiteHints[idx] != null) return callsiteHints[idx];
+          break;
+        }
+      }
+    }
+    return TYPES.UNKNOWN;
+  }
+
+  // literal / math / boolean / etc.
+  return getType(argBlock.type);
+}
 
 export function adjustStaticName(name) {
   if(name.startsWith('static_')) {
@@ -760,6 +836,34 @@ export class JavascriptGenerator extends Blockly.CodeGenerator {
     /*if (defvars.length) {
       this.definitions_['variables'] = 'var ' + defvars.join(', ') + ';';
     }*/
+    // ── Scan callconstructor blocks → store cross-class parameter type hints ──
+    // When this workspace calls new OtherClass(arg, ...) we persist the inferred
+    // argument types so OtherClass's defconstructor can use them even though the
+    // call site lives in a different class workspace.
+    const _callerClass = getClassName();
+    if (_callerClass) {
+      const _callHintsByCallee = {};
+      for (const callBlock of workspace.getBlocksByType('callconstructor', true)) {
+        const _dv = callBlock.getFieldValue('CONSTRUCTOR_CLASS') || '';
+        const _sep = _dv.indexOf(':::');
+        if (_sep < 0) continue;
+        const _calledClass = _dv.slice(0, _sep);
+        if (!_calledClass || _calledClass === 'NONE') continue;
+        const _types = [];
+        // inputList[0] is the TOP_LINE dummy; argument inputs start at 1.
+        for (let _n = 1; _n < callBlock.inputList.length; _n++) {
+          const _conn = callBlock.inputList[_n].connection;
+          const _argBlock = _conn ? _conn.targetBlock() : null;
+          const _t = resolveArgBlockType(_argBlock, workspace);
+          _types.push(_t !== TYPES.UNKNOWN ? _t : null);
+        }
+        if (_types.some(_t => _t !== null)) {
+          _callHintsByCallee[_calledClass] = _types;
+        }
+      }
+      LocalStorageManager.storeConstructorCallsiteHintsByClass(_callerClass, _callHintsByCallee);
+    }
+
     this.isInitialized = true;
   }
 

--- a/custom-generator-codelab/src/index.html
+++ b/custom-generator-codelab/src/index.html
@@ -170,6 +170,14 @@
                             <svg width="16" height="16" viewBox="0 0 16 16" aria-hidden="true"><use href="#icon-upload"/></svg>
                             <span>Import</span>
                         </button>
+                        <button id="toolboxConfigBtn" class="git-sidebar-btn" title="Toolbox-Konfiguration bearbeiten" aria-label="Toolbox-Konfiguration bearbeiten" style="opacity:0.45;font-size:10px;">
+                            <svg width="14" height="14" viewBox="0 0 16 16" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                                <rect x="1.5" y="4" width="13" height="9" rx="1.5"/>
+                                <line x1="4" y1="7.5" x2="12" y2="7.5"/>
+                                <line x1="4" y1="10" x2="9" y2="10"/>
+                            </svg>
+                            <span>Config</span>
+                        </button>
                     </div>
                 </div>
             </nav>

--- a/custom-generator-codelab/src/index.html
+++ b/custom-generator-codelab/src/index.html
@@ -247,7 +247,7 @@
                             'withFileList': true ,
                             'withErrorList': true,
                             'enableFileAccess': true,
-                            'withClassDiagram': false,
+                            'withClassDiagram': true,
                             'hideUnitTests': true,
                             'hideWorkspaceFilesMng': true,
                             'simplifyDebugger': true,

--- a/custom-generator-codelab/src/index.js
+++ b/custom-generator-codelab/src/index.js
@@ -57,7 +57,7 @@ function init() {
   // Restore a toolbox config that was applied in a previous session,
   // or apply the grade-9 default when the page is opened for the first time.
   const storedToolboxConfig = ToolboxConfigManager.loadStored();
-  ToolboxConfigManager.apply(storedToolboxConfig ?? FULL_ACTIVE_CONFIG, ws);
+  ToolboxConfigManager.applyConfig(storedToolboxConfig ?? FULL_ACTIVE_CONFIG, ws);
 
   // Load the initial state from storage and run the code.
   load(ws);
@@ -589,7 +589,7 @@ async function handleClone() {
     dismiss();
 
     // Apply toolbox config from the repo (resets to full toolbox when absent).
-    ToolboxConfigManager.apply(files.toolboxConfig, ws);
+    ToolboxConfigManager.applyConfig(files.toolboxConfig, ws);
 
     // Import Java and Markdown files into the Online-IDE.
     importJavaFilesToIDE({ ...files.java, ...files.md });
@@ -674,7 +674,7 @@ async function handlePull() {
     dismiss();
 
     // Apply toolbox config from the repo (resets to full toolbox when absent).
-    ToolboxConfigManager.apply(files.toolboxConfig, ws);
+    ToolboxConfigManager.applyConfig(files.toolboxConfig, ws);
 
     importJavaFilesToIDE({ ...files.java, ...files.md });
 

--- a/custom-generator-codelab/src/index.js
+++ b/custom-generator-codelab/src/index.js
@@ -194,12 +194,21 @@ function setupListeners(workspace) {
   });
 
   // Re-generate code after every meaningful workspace change.
+  // The listener is DEBOUNCED: we wait until the current JS task (and all
+  // synchronous workspace events it produces) finishes before running code
+  // generation.  Without this, a single block-shape mutation (which fires a
+  // burst of removeInput / appendInput / setValue events) would trigger
+  // onBlocksChange() for each individual event, and each call would swap
+  // workspaces via silentGenerateForClass → load(ws) mid-mutation, creating
+  // an endless event→generation→swap→event loop.
+  let _codeGenTimer = null;
   workspace.addChangeListener((e) => {
     if (e.isUiEvent || e.type == Blockly.Events.FINISHED_LOADING ||
       workspace.isDragging()) {
       return;
     }
-    onBlocksChange();
+    clearTimeout(_codeGenTimer);
+    _codeGenTimer = setTimeout(() => onBlocksChange(), 0);
   });
 
   // Clean up orphaned 'param' variables whenever any block is deleted.

--- a/custom-generator-codelab/src/index.js
+++ b/custom-generator-codelab/src/index.js
@@ -11,7 +11,7 @@ import {toolbox} from './toolboxGrade9';
 import * as CTR from './blocks/constructor.js';
 import { methodFlyoutCategory, normalAttrFlyoutCategory, localVarFlyoutCategory, staticAttrFlyoutCategory, paramFlyoutCategory, allVariablesFlyoutCategory, allAttrFlyoutCategory } from './blocks/java_variable_blocks.js';
 import * as JAVA_METHODS from './blocks/java_method_blocks.js';
-import {getClassName} from "./generators/javascript/javascript_generator";
+import {getClassName, setClassName} from "./generators/javascript/javascript_generator";
 import LocalStorageManager from "./utils/LocalStorageManager.js";
 
 import './styles/stylesheet.css';
@@ -30,6 +30,10 @@ import { BlocklyOverlayManager } from './utils/BlocklyOverlayManager';
 
 // Module-level state
 export let ws;
+
+/** Guard: prevents the workspace change listener from re-entering onBlocksChange
+ *  while a background multi-pass generation is in progress. */
+let _batchGenerating = false;
 
 // Instantiate managers
 // Passing onXmlLoaded as callback for REST response
@@ -241,6 +245,9 @@ function setupListeners(workspace) {
  * the last active Java file first.
  */
 export function onBlocksChange() {
+  // Do not re-enter while a background multi-pass generation is in progress.
+  if (_batchGenerating) return;
+
   // If the IDE is showing a .md file, switch it back to the Java file.
   IdeBridge.ensureJavaFileActive();
 
@@ -254,13 +261,57 @@ export function onBlocksChange() {
     return;
   }
 
+  // ── Pass 0: generate the currently active class ─────────────────────────
+  // This populates its callsite hints (e.g. new Child(42)) in localStorage
+  // so the background passes below can read them for downstream classes.
   LocalStorageManager.clearConstructors(getClassName());
   LocalStorageManager.clearMethods(getClassName());
 
   const rawCode = generateCode();
   const modCode = CodeTransformer.transformCode(rawCode);
   IdeBridge.pushCodeToIDE(modCode);
+
+  // ── Background multi-pass: propagate type hints across all other classes ─
+  // Pass 1: each other class reads hints written by pass 0 (or older state).
+  // Pass 2: classes further down the inheritance chain (e.g. Super) pick up
+  //         the super-call hints written by pass 1 (e.g. in Child).
+  // After both passes the active class is re-generated so IT benefits too
+  // from any hints that were updated during the background passes.
+  _batchGenerating = true;
+  try {
+    const activeClass = getClassName();
+    const allConstructors = LocalStorageManager.getAllConstructors() ?? {};
+    const otherClasses = Object.keys(allConstructors).filter(
+      c => c && c !== activeClass && !LocalStorageManager.isJavaModified(c)
+    );
+
+    if (otherClasses.length > 0) {
+      // Pass 1 — propagate from active class outward.
+      for (const cls of otherClasses) {
+        silentGenerateForClass(cls);
+      }
+      // Pass 2 — handle indirect chains (A→B→C: B must be done before C).
+      for (const cls of otherClasses) {
+        silentGenerateForClass(cls);
+      }
+
+      // Restore the active class workspace so the user still sees their class.
+      IdeBridge.selected_file_name = activeClass + '.java';
+      setClassName(activeClass);
+      load(ws);
+
+      // Re-generate the active class now that all downstream hints are fresh.
+      LocalStorageManager.clearConstructors(activeClass);
+      LocalStorageManager.clearMethods(activeClass);
+      const rawCode2 = generateCode();
+      const modCode2 = CodeTransformer.transformCode(rawCode2);
+      IdeBridge.pushCodeToIDE(modCode2);
+    }
+  } finally {
+    _batchGenerating = false;
+  }
 }
+
 
 
 // ---------------------------------------------------------------------------
@@ -298,6 +349,51 @@ function onXmlLoaded(xhttp) {
 function generateCode() {
   return javaGenerator.workspaceToCode(ws);
 }
+
+// ---------------------------------------------------------------------------
+// Background silent generation helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Silently loads, generates, transforms, and pushes code for an arbitrary
+ * class without disturbing the currently visible workspace.
+ *
+ * The workspace is swapped in with events disabled so no UI repaint or
+ * spurious onBlocksChange() calls occur.  selected_file_name is temporarily
+ * overwritten so that load() and pushCodeToIDEForClass() target the right
+ * storage keys, then restored before returning.
+ *
+ * @param {string} className  Name of the class to (re)generate (no .java).
+ */
+function silentGenerateForClass(className) {
+  if (!className) return;
+  if (LocalStorageManager.isJavaModified(className)) return;
+
+  // Bail out if there is no saved workspace for this class.
+  const data = LocalStorageManager.loadWorkspace(className);
+  if (!data) return;
+
+  // Redirect load/save to the target class.
+  const prevFileName = IdeBridge.selected_file_name;
+  IdeBridge.selected_file_name = className + '.java';
+
+  setClassName(className);
+  LocalStorageManager.clearConstructors(className);
+  LocalStorageManager.clearMethods(className);
+
+  // load() internally calls Blockly.Events.disable/enable, so the workspace
+  // change listener won't fire and trigger a recursive onBlocksChange().
+  load(ws);
+
+  const rawCode = generateCode();
+  const modCode = CodeTransformer.transformCode(rawCode);
+  IdeBridge.pushCodeToIDEForClass(className, modCode);
+
+  // Restore the previously selected file name so subsequent calls and the
+  // final restore in onBlocksChange() operate on the right class.
+  IdeBridge.selected_file_name = prevFileName;
+}
+
 
 
 // ---------------------------------------------------------------------------

--- a/custom-generator-codelab/src/index.js
+++ b/custom-generator-codelab/src/index.js
@@ -9,7 +9,7 @@ import {javaGenerator} from './generators/java';
 import {save, load} from './serialization';
 import {toolbox} from './toolboxGrade9';
 import * as CTR from './blocks/constructor.js';
-import { methodFlyoutCategory, normalAttrFlyoutCategory, localVarFlyoutCategory, staticAttrFlyoutCategory, paramFlyoutCategory, allVariablesFlyoutCategory } from './blocks/java_variable_blocks.js';
+import { methodFlyoutCategory, normalAttrFlyoutCategory, localVarFlyoutCategory, staticAttrFlyoutCategory, paramFlyoutCategory, allVariablesFlyoutCategory, allAttrFlyoutCategory } from './blocks/java_variable_blocks.js';
 import * as JAVA_METHODS from './blocks/java_method_blocks.js';
 import {getClassName} from "./generators/javascript/javascript_generator";
 import LocalStorageManager from "./utils/LocalStorageManager.js";
@@ -93,6 +93,7 @@ function setupBlockly(theme) {
   workspace.registerToolboxCategoryCallback('JAVA_STATIC_ATTR', staticAttrFlyoutCategory);
   workspace.registerToolboxCategoryCallback('JAVA_PARAM', paramFlyoutCategory);
   workspace.registerToolboxCategoryCallback('JAVA_VARIABLES_ALL', allVariablesFlyoutCategory);
+  workspace.registerToolboxCategoryCallback('JAVA_ATTR', allAttrFlyoutCategory);
 
   // Button callbacks: open the built-in dialog but create a typed variable.
   workspace.registerButtonCallback('CREATE_JAVA_NORMAL_ATTR',
@@ -101,7 +102,10 @@ function setupBlockly(theme) {
     (btn) => Blockly.Variables.createVariableButtonHandler(btn.getTargetWorkspace(), null, 'local'));
   workspace.registerButtonCallback('CREATE_JAVA_STATIC_ATTR',
     (btn) => Blockly.Variables.createVariableButtonHandler(btn.getTargetWorkspace(), null, 'static'));
-
+  // Toolbox config editor button.
+  document.getElementById('toolboxConfigBtn')?.addEventListener('click', () => {
+    ToolboxConfigManager.openConfigEditor(ws, FULL_ACTIVE_CONFIG);
+  });
   return workspace;
 }
 

--- a/custom-generator-codelab/src/index.js
+++ b/custom-generator-codelab/src/index.js
@@ -265,6 +265,7 @@ export function onBlocksChange() {
   // Do not overwrite manually edited Java code.  This guard covers every call
   // site: Blockly events, post-import, post-clone/pull, etc.
   const className = IdeBridge.selected_file_name.replace('.java', '');
+  if (!className) return;
   if (className && LocalStorageManager.isJavaModified(className)) {
     BlocklyOverlayManager.show();
     return;
@@ -442,13 +443,16 @@ function setupWorkspaceActions() {
       const confirmed = await GitDialog.showClearConfirm();
       if (!confirmed) return;
 
-      WorkspaceManager.clearWorkspace(ws);
+      for(var i = 0; i < 2; i++) {
+          WorkspaceManager.clearWorkspace(ws);
 
-      // Push freshly generated code (empty template) into the new Main.java.
-      onBlocksChange();
+        // Push freshly generated code (empty template) into the new Main.java.
+        onBlocksChange();
 
-      // After clearing, update git button states (clone becomes available again).
-      updateGitButtonStates();
+        // After clearing, update git button states (clone becomes available again).
+        updateGitButtonStates();
+
+      }
     });
   }
 

--- a/custom-generator-codelab/src/index.js
+++ b/custom-generator-codelab/src/index.js
@@ -251,6 +251,7 @@ export function onBlocksChange() {
   }
 
   LocalStorageManager.clearConstructors(getClassName());
+  LocalStorageManager.clearMethods(getClassName());
 
   const rawCode = generateCode();
   const modCode = CodeTransformer.transformCode(rawCode);

--- a/custom-generator-codelab/src/serialization.js
+++ b/custom-generator-codelab/src/serialization.js
@@ -36,7 +36,8 @@ export const load = function(workspace) {
     console.warn('No file selected, skipping workspace save.');
     return;
   }
-  const data = LocalStorageManager.loadWorkspace(className) || JSON.stringify(emptyTemplate);
+  const defaultTemplate = className === 'Main' ? emptyTemplate : { blocks: { languageVersion: 0, blocks: [] } };
+  const data = LocalStorageManager.loadWorkspace(className) || JSON.stringify(defaultTemplate);
 
   // Don't emit events during loading.
   Blockly.Events.disable();

--- a/custom-generator-codelab/src/styles/ide.css
+++ b/custom-generator-codelab/src/styles/ide.css
@@ -115,8 +115,9 @@ g.blocklyWorkspace {
 .jo_iconButton .img_delete-dark,
 .jo_iconButton .img_start-dark */
 {
-    width: 20px;
-    height: 20px;
+    width: 25px;
+    height: 25px;
+    margin-left: 15px;
     background-size: contain;
 }
 

--- a/custom-generator-codelab/src/toolboxGrade9.js
+++ b/custom-generator-codelab/src/toolboxGrade9.js
@@ -606,6 +606,14 @@ export const toolbox = {
                 {
                     kind: "block",
                     type: "callconstructor"
+                },
+                {
+                    kind: "block",
+                    type: "java_extends"
+                },
+                {
+                    kind: "block",
+                    type: "java_super_call"
                 }
             ]
         }

--- a/custom-generator-codelab/src/toolboxGrade9.js
+++ b/custom-generator-codelab/src/toolboxGrade9.js
@@ -582,8 +582,20 @@ export const toolbox = {
         {
             'kind': 'category',
             'name': 'Variablen',
-            'categorystyle': 'variable_category',
+            'colour': '#55AA55',
             'custom': 'JAVA_VARIABLES_ALL',
+        },
+        {
+            'kind': 'category',
+            'name': 'Attribute',
+            'categorystyle': 'variable_category',
+            'custom': 'JAVA_ATTR',
+        },
+        {
+            'kind': 'category',
+            'name': 'Parameter',
+            'colour': '#CC8800',
+            'custom': 'JAVA_PARAM',
         },
         {
             'kind': 'sep',

--- a/custom-generator-codelab/src/utils/CodeTransformer.js
+++ b/custom-generator-codelab/src/utils/CodeTransformer.js
@@ -1,4 +1,4 @@
-import { getClassName } from "../generators/javascript/javascript_generator";
+import { getClassName, getExtendsClass } from "../generators/javascript/javascript_generator";
 
 export class CodeTransformer {
   /**
@@ -34,7 +34,8 @@ export class CodeTransformer {
 
   static defaultCodePrefix(modCode) {
     const comm = "/**\nErstelle dein Programm über Blockly und\nklicke auf 'Play', um es auszuführen!\n*/\n\n";
-    const codePrefix = 'public class ' + getClassName() + ' { \n';
+    const extendsClause = getExtendsClass() ? ' extends ' + getExtendsClass() : '';
+    const codePrefix = 'public class ' + getClassName() + extendsClause + ' { \n';
     return comm + codePrefix + modCode + '\n}';
   }
 

--- a/custom-generator-codelab/src/utils/IdeBridge.js
+++ b/custom-generator-codelab/src/utils/IdeBridge.js
@@ -40,10 +40,11 @@ export class IdeBridge {
     const ideAccess = globalThis.online_ide_access.getIDE('Java');
     const files = ideAccess.getFiles();
     const selectedFileName = this.selected_file_name;
+    if (!selectedFileName) return;
 
     for (const element of files) {
       const file = element;
-      if (file.getName() === selectedFileName || selectedFileName === '') {
+      if (file.getName() === selectedFileName) {
         //console.log('Name: ' + file.getName());
         file.setText(modCode);
       }
@@ -143,8 +144,8 @@ export class IdeBridge {
 
     // If the deleted file was currently active, clear the Blockly workspace.
     if (this.selected_file_name === fileName) {
-      Blockly.getMainWorkspace()?.clear();
       this.selected_file_name = '';
+      Blockly.getMainWorkspace()?.clear();
       this.syncClassNameFromIDE();
     }
   }

--- a/custom-generator-codelab/src/utils/IdeBridge.js
+++ b/custom-generator-codelab/src/utils/IdeBridge.js
@@ -64,6 +64,32 @@ export class IdeBridge {
   }
 
   /**
+   * Pushes generated code to the IDE file for a specific class without
+   * affecting the overlay or the currently selected file name.
+   * Intended for background (batch) re-generation passes.
+   * @param {string} className  Class name (without .java extension)
+   * @param {string} modCode    Transformed Java code to write
+   */
+  static pushCodeToIDEForClass(className, modCode) {
+    if (!globalThis.online_ide_access) return;
+    const ideAccess = globalThis.online_ide_access.getIDE?.('Java');
+    if (!ideAccess) return;
+
+    const fileName = className + '.java';
+    for (const file of ideAccess.getFiles()) {
+      if (file.getName() === fileName) {
+        file.setText(modCode);
+        break;
+      }
+    }
+
+    // Persist baseline and clear the java-modified flag so later polls
+    // don't misidentify Blockly's own output as a manual edit.
+    LocalStorageManager.saveLastGeneratedCode(className, modCode);
+    LocalStorageManager.setJavaModified(className, false);
+  }
+
+  /**
    * Returns the current text content of the selected file as shown in the IDE
    * editor, or null if the IDE is not ready / no file is selected.
    * Used by BlocklyOverlayManager to detect manual edits.

--- a/custom-generator-codelab/src/utils/LocalStorageManager.js
+++ b/custom-generator-codelab/src/utils/LocalStorageManager.js
@@ -339,6 +339,17 @@ class LocalStorageManager {
             }
             if (csChanged2) globalThis.localStorage?.setItem(this.CONSTRUCTOR_CALLSITE_HINTS_KEY, JSON.stringify(csStore2));
         }
+
+        // Migrate method definitions keyed by class name.
+        const methodDefsRaw = globalThis.localStorage?.getItem(this.METHODS_STORAGE_KEY);
+        if (methodDefsRaw) {
+            const methodDefsStore = JSON.parse(methodDefsRaw) || {};
+            if (methodDefsStore[className] !== undefined) {
+                methodDefsStore[newClassName] = methodDefsStore[className];
+                delete methodDefsStore[className];
+                globalThis.localStorage?.setItem(this.METHODS_STORAGE_KEY, JSON.stringify(methodDefsStore));
+            }
+        }
         // Migrate super-call type hints where className appears as either
         // the sub-class key or the parentClass value.
         const hintsRaw = globalThis.localStorage?.getItem(this.SUPER_CALL_TYPE_HINTS_KEY);

--- a/custom-generator-codelab/src/utils/LocalStorageManager.js
+++ b/custom-generator-codelab/src/utils/LocalStorageManager.js
@@ -165,12 +165,14 @@ class LocalStorageManager {
         const store = JSON.parse(raw) || {};
         let merged = null;
         for (const calleeMap of Object.values(store)) {
-            const types = calleeMap && calleeMap[calledClass];
-            if (!types) continue;
-            if (!merged) merged = types.slice();
-            else {
-                for (let i = 0; i < types.length; i++) {
-                    if (merged[i] == null && types[i] != null) merged[i] = types[i];
+            const types = calleeMap?.[calledClass];
+            if (types) {
+                if (merged) {
+                    for (let i = 0; i < types.length; i++) {
+                        if (merged[i] == null && types[i] != null) merged[i] = types[i];
+                    }
+                } else {
+                    merged = types.slice();
                 }
             }
         }
@@ -236,10 +238,40 @@ class LocalStorageManager {
         return JSON.parse(raw) || {};
     }
 
+    /** @param {string} className */
+    static _removeCallsiteHintsForClass(className) {
+        const csRaw = globalThis.localStorage?.getItem(this.CONSTRUCTOR_CALLSITE_HINTS_KEY);
+        if (!csRaw) return;
+        const csStore = JSON.parse(csRaw) || {};
+        let csChanged = false;
+        if (csStore[className]) { delete csStore[className]; csChanged = true; }
+        for (const calleeMap of Object.values(csStore)) {
+            if (calleeMap?.[className]) {
+                delete calleeMap[className]; csChanged = true;
+            }
+        }
+        if (csChanged) globalThis.localStorage?.setItem(this.CONSTRUCTOR_CALLSITE_HINTS_KEY, JSON.stringify(csStore));
+    }
+
+    /** @param {string} className */
+    static _removeSuperHintsForClass(className) {
+        const hintsRaw = globalThis.localStorage?.getItem(this.SUPER_CALL_TYPE_HINTS_KEY);
+        if (!hintsRaw) return;
+        const store = JSON.parse(hintsRaw) || {};
+        let changed = false;
+        for (const [sub, entry] of Object.entries(store)) {
+            if (sub === className || entry?.parentClass === className) {
+                delete store[sub];
+                changed = true;
+            }
+        }
+        if (changed) globalThis.localStorage?.setItem(this.SUPER_CALL_TYPE_HINTS_KEY, JSON.stringify(store));
+    }
+
     static deleteClass(className) {
         let ctrs = globalThis.localStorage?.getItem(this.CTR_STORAGE_KEY);
         let ctrObjs = JSON.parse(ctrs) || {};
-        if(ctrObjs[className] != null) {
+        if (ctrObjs[className] != null) {
             delete ctrObjs[className];
             globalThis.localStorage?.setItem(this.CTR_STORAGE_KEY, JSON.stringify(ctrObjs));
         }
@@ -253,36 +285,10 @@ class LocalStorageManager {
         // Clean up stored method definitions.
         this.clearMethods(className);
         // Clean up callsite hints where this class appears as caller or callee.
-        const csRaw = globalThis.localStorage?.getItem(this.CONSTRUCTOR_CALLSITE_HINTS_KEY);
-        if (csRaw) {
-            const csStore = JSON.parse(csRaw) || {};
-            let csChanged = false;
-            // Remove entry where className is the caller.
-            if (csStore[className]) { delete csStore[className]; csChanged = true; }
-            // Remove callee references inside other callers' entries.
-            for (const calleeMap of Object.values(csStore)) {
-                if (calleeMap && calleeMap[className]) {
-                    delete calleeMap[className]; csChanged = true;
-                }
-            }
-            if (csChanged) globalThis.localStorage?.setItem(this.CONSTRUCTOR_CALLSITE_HINTS_KEY, JSON.stringify(csStore));
-        }
+        this._removeCallsiteHintsForClass(className);
         // Clean up super-call type hints where this class appears as either
         // the sub-class key or the parentClass value.
-        const hintsRaw = globalThis.localStorage?.getItem(this.SUPER_CALL_TYPE_HINTS_KEY);
-        if (hintsRaw) {
-            const store = JSON.parse(hintsRaw) || {};
-            let changed = false;
-            for (const [sub, entry] of Object.entries(store)) {
-                if (sub === className || (entry && entry.parentClass === className)) {
-                    delete store[sub];
-                    changed = true;
-                }
-            }
-            if (changed) {
-                globalThis.localStorage?.setItem(this.SUPER_CALL_TYPE_HINTS_KEY, JSON.stringify(store));
-            }
-        }
+        this._removeSuperHintsForClass(className);
     }
 
     static renameClass(className, newClassName) {
@@ -331,7 +337,7 @@ class LocalStorageManager {
                 csChanged2 = true;
             }
             for (const calleeMap of Object.values(csStore2)) {
-                if (calleeMap && calleeMap[className] !== undefined) {
+                if (calleeMap?.[className] !== undefined) {
                     calleeMap[newClassName] = calleeMap[className];
                     delete calleeMap[className];
                     csChanged2 = true;
@@ -352,27 +358,31 @@ class LocalStorageManager {
         }
         // Migrate super-call type hints where className appears as either
         // the sub-class key or the parentClass value.
+        this._migrateSuperHints(className, newClassName);
+    }
+
+    /**
+     * Renames all super-call type hint entries that reference className.
+     * @param {string} oldName
+     * @param {string} newName
+     */
+    static _migrateSuperHints(oldName, newName) {
         const hintsRaw = globalThis.localStorage?.getItem(this.SUPER_CALL_TYPE_HINTS_KEY);
-        if (hintsRaw) {
-            const store = JSON.parse(hintsRaw) || {};
-            let changed = false;
-            // Rename sub-class key.
-            if (store[className] !== undefined) {
-                store[newClassName] = store[className];
-                delete store[className];
+        if (!hintsRaw) return;
+        const store = JSON.parse(hintsRaw) || {};
+        let changed = false;
+        if (store[oldName] !== undefined) {
+            store[newName] = store[oldName];
+            delete store[oldName];
+            changed = true;
+        }
+        for (const entry of Object.values(store)) {
+            if (entry?.parentClass === oldName) {
+                entry.parentClass = newName;
                 changed = true;
             }
-            // Rename parentClass references.
-            for (const entry of Object.values(store)) {
-                if (entry && entry.parentClass === className) {
-                    entry.parentClass = newClassName;
-                    changed = true;
-                }
-            }
-            if (changed) {
-                globalThis.localStorage?.setItem(this.SUPER_CALL_TYPE_HINTS_KEY, JSON.stringify(store));
-            }
         }
+        if (changed) globalThis.localStorage?.setItem(this.SUPER_CALL_TYPE_HINTS_KEY, JSON.stringify(store));
     }
 
     static createClass(className) {

--- a/custom-generator-codelab/src/utils/LocalStorageManager.js
+++ b/custom-generator-codelab/src/utils/LocalStorageManager.js
@@ -3,6 +3,8 @@ class LocalStorageManager {
     static WORKSPACE_STORAGE_KEY = '';
     static CTR_STORAGE_KEY = 'constructors';
     static METHODS_STORAGE_KEY = 'methodDefinitions';
+    static SUPER_CALL_TYPE_HINTS_KEY = 'superCallTypeHints';
+    static CONSTRUCTOR_CALLSITE_HINTS_KEY = 'constructorCallsiteHints';
     static JAVA_MODIFIED_KEY_PREFIX  = 'javaModified_';
     static JAVA_GENERATED_KEY_PREFIX = 'javaGenerated_';
     
@@ -18,10 +20,17 @@ class LocalStorageManager {
         ctrObjs[className] = [];
         globalThis.localStorage?.setItem(this.CTR_STORAGE_KEY, JSON.stringify(ctrObjs));
         //console.log("Remaining constructors: "+JSON.stringify(ctrObjs));
+        // Clear any super-call type hints this class wrote as a sub-class.
+        // This ensures stale hints are never used on the next generation.
+        this.clearSubClassTypeHints(className);
+        // Clear callsite hints this class stored as a caller.
+        this._clearConstructorCallsiteHintsByCaller(className);
     }
 
     static clearAllConstructors() {
         globalThis.localStorage?.setItem(this.CTR_STORAGE_KEY, JSON.stringify({}));
+        globalThis.localStorage?.setItem(this.SUPER_CALL_TYPE_HINTS_KEY, JSON.stringify({}));
+        globalThis.localStorage?.setItem(this.CONSTRUCTOR_CALLSITE_HINTS_KEY, JSON.stringify({}));
         //console.log("Cleared all stored constructors.");
     }
 
@@ -49,6 +58,136 @@ class LocalStorageManager {
         let ctrs = globalThis.localStorage?.getItem(this.CTR_STORAGE_KEY);
         const ret = JSON.parse(ctrs) || {};
         return ret;
+    }
+
+    // ── Super-call parameter type hints ──────────────────────────────────────
+    //
+    // Hints are keyed by SUB-CLASS name so they are automatically replaced
+    // every time the sub-class is regenerated (clearConstructors clears them).
+    //
+    // Storage format:
+    //   { "Test": { parentClass: "Super", hints: { x: "String" } }, … }
+
+    /**
+     * Stores/replaces inferred parameter types written by a java_super_call
+     * block in a sub-class workspace.
+     *
+     * @param {string} subClassName   – the class that contains the super() call
+     * @param {string} parentClassName – the class being called
+     * @param {Object.<string, string>} typeHints – param name → Java type
+     */
+    static storeSuperCallTypeHints(subClassName, parentClassName, typeHints) {
+        if (!subClassName || !parentClassName) return;
+        const raw = globalThis.localStorage?.getItem(this.SUPER_CALL_TYPE_HINTS_KEY);
+        const store = JSON.parse(raw) || {};
+        // Replace entirely – don't merge so stale entries can't survive.
+        store[subClassName] = { parentClass: parentClassName, hints: typeHints };
+        globalThis.localStorage?.setItem(this.SUPER_CALL_TYPE_HINTS_KEY, JSON.stringify(store));
+    }
+
+    /**
+     * Clears hints written by the given sub-class.
+     * Called from clearConstructors so stale data is removed before each
+     * code-generation pass.
+     *
+     * @param {string} subClassName
+     */
+    static clearSubClassTypeHints(subClassName) {
+        if (!subClassName) return;
+        const raw = globalThis.localStorage?.getItem(this.SUPER_CALL_TYPE_HINTS_KEY);
+        const store = JSON.parse(raw) || {};
+        if (store[subClassName]) {
+            delete store[subClassName];
+            globalThis.localStorage?.setItem(this.SUPER_CALL_TYPE_HINTS_KEY, JSON.stringify(store));
+        }
+    }
+
+    /**
+     * Retrieves the merged parameter type hints for a given parent class by
+     * scanning all sub-class entries.
+     *
+     * @param {string} parentClassName
+     * @returns {Object.<string, string>|null} param name → Java type, or null
+     */
+    // ── Constructor call-site type hints ──────────────────────────────────────
+    //
+    // When class A calls `new B(arg0, arg1)`, the inferred types of arg0/arg1
+    // are stored here keyed by A (the caller).  When generating B, the stored
+    // list for B is retrieved by scanning all callers.
+    //
+    // Storage format:
+    //   { "Main": { "Child": ["double", null] }, "Other": { "Child": ["String"] } }
+
+    /**
+     * Replaces the callsite type hints stored by callerClass for every class
+     * it calls with `new`.
+     *
+     * @param {string} callerClass
+     * @param {Object.<string, Array<string|null>>} hintsByCallee
+     *   Mapping from called-class name to an array of Java types indexed by
+     *   constructor parameter position (null when type could not be inferred).
+     */
+    static storeConstructorCallsiteHintsByClass(callerClass, hintsByCallee) {
+        if (!callerClass) return;
+        const raw = globalThis.localStorage?.getItem(this.CONSTRUCTOR_CALLSITE_HINTS_KEY);
+        const store = JSON.parse(raw) || {};
+        store[callerClass] = hintsByCallee || {};
+        globalThis.localStorage?.setItem(this.CONSTRUCTOR_CALLSITE_HINTS_KEY, JSON.stringify(store));
+    }
+
+    /**
+     * Clears all callsite hints that were stored by callerClass.
+     * Called from clearConstructors so stale hints are wiped before each
+     * code-generation pass.
+     *
+     * @param {string} callerClass
+     */
+    static _clearConstructorCallsiteHintsByCaller(callerClass) {
+        if (!callerClass) return;
+        const raw = globalThis.localStorage?.getItem(this.CONSTRUCTOR_CALLSITE_HINTS_KEY);
+        const store = JSON.parse(raw) || {};
+        if (store[callerClass]) {
+            delete store[callerClass];
+            globalThis.localStorage?.setItem(this.CONSTRUCTOR_CALLSITE_HINTS_KEY, JSON.stringify(store));
+        }
+    }
+
+    /**
+     * Returns the merged parameter type array for calledClass by scanning all
+     * caller entries (first non-null value per index wins).
+     *
+     * @param {string} calledClass
+     * @returns {Array<string|null>|null}
+     */
+    static getConstructorCallsiteHints(calledClass) {
+        const raw = globalThis.localStorage?.getItem(this.CONSTRUCTOR_CALLSITE_HINTS_KEY);
+        const store = JSON.parse(raw) || {};
+        let merged = null;
+        for (const calleeMap of Object.values(store)) {
+            const types = calleeMap && calleeMap[calledClass];
+            if (!types) continue;
+            if (!merged) merged = types.slice();
+            else {
+                for (let i = 0; i < types.length; i++) {
+                    if (merged[i] == null && types[i] != null) merged[i] = types[i];
+                }
+            }
+        }
+        return merged;
+    }
+
+    static getSuperCallTypeHints(parentClassName) {
+        const raw = globalThis.localStorage?.getItem(this.SUPER_CALL_TYPE_HINTS_KEY);
+        const store = JSON.parse(raw) || {};
+        const merged = {};
+        let found = false;
+        for (const entry of Object.values(store)) {
+            if (entry && entry.parentClass === parentClassName && entry.hints) {
+                Object.assign(merged, entry.hints);
+                found = true;
+            }
+        }
+        return found ? merged : null;
     }
 
     // ── Method-definition storage ─────────────────────────────────────────────
@@ -112,6 +251,37 @@ class LocalStorageManager {
         globalThis.localStorage?.removeItem(this.JAVA_GENERATED_KEY_PREFIX + className);
         // Clean up stored method definitions.
         this.clearMethods(className);
+        // Clean up callsite hints where this class appears as caller or callee.
+        const csRaw = globalThis.localStorage?.getItem(this.CONSTRUCTOR_CALLSITE_HINTS_KEY);
+        if (csRaw) {
+            const csStore = JSON.parse(csRaw) || {};
+            let csChanged = false;
+            // Remove entry where className is the caller.
+            if (csStore[className]) { delete csStore[className]; csChanged = true; }
+            // Remove callee references inside other callers' entries.
+            for (const calleeMap of Object.values(csStore)) {
+                if (calleeMap && calleeMap[className]) {
+                    delete calleeMap[className]; csChanged = true;
+                }
+            }
+            if (csChanged) globalThis.localStorage?.setItem(this.CONSTRUCTOR_CALLSITE_HINTS_KEY, JSON.stringify(csStore));
+        }
+        // Clean up super-call type hints where this class appears as either
+        // the sub-class key or the parentClass value.
+        const hintsRaw = globalThis.localStorage?.getItem(this.SUPER_CALL_TYPE_HINTS_KEY);
+        if (hintsRaw) {
+            const store = JSON.parse(hintsRaw) || {};
+            let changed = false;
+            for (const [sub, entry] of Object.entries(store)) {
+                if (sub === className || (entry && entry.parentClass === className)) {
+                    delete store[sub];
+                    changed = true;
+                }
+            }
+            if (changed) {
+                globalThis.localStorage?.setItem(this.SUPER_CALL_TYPE_HINTS_KEY, JSON.stringify(store));
+            }
+        }
     }
 
     static renameClass(className, newClassName) {
@@ -147,6 +317,49 @@ class LocalStorageManager {
         if (generatedVal != null) {
             globalThis.localStorage?.setItem(this.JAVA_GENERATED_KEY_PREFIX + newClassName, generatedVal);
             globalThis.localStorage?.removeItem(this.JAVA_GENERATED_KEY_PREFIX + className);
+        }
+
+        // Migrate callsite hints where className appears as caller or callee.
+        const csRaw2 = globalThis.localStorage?.getItem(this.CONSTRUCTOR_CALLSITE_HINTS_KEY);
+        if (csRaw2) {
+            const csStore2 = JSON.parse(csRaw2) || {};
+            let csChanged2 = false;
+            if (csStore2[className] !== undefined) {
+                csStore2[newClassName] = csStore2[className];
+                delete csStore2[className];
+                csChanged2 = true;
+            }
+            for (const calleeMap of Object.values(csStore2)) {
+                if (calleeMap && calleeMap[className] !== undefined) {
+                    calleeMap[newClassName] = calleeMap[className];
+                    delete calleeMap[className];
+                    csChanged2 = true;
+                }
+            }
+            if (csChanged2) globalThis.localStorage?.setItem(this.CONSTRUCTOR_CALLSITE_HINTS_KEY, JSON.stringify(csStore2));
+        }
+        // Migrate super-call type hints where className appears as either
+        // the sub-class key or the parentClass value.
+        const hintsRaw = globalThis.localStorage?.getItem(this.SUPER_CALL_TYPE_HINTS_KEY);
+        if (hintsRaw) {
+            const store = JSON.parse(hintsRaw) || {};
+            let changed = false;
+            // Rename sub-class key.
+            if (store[className] !== undefined) {
+                store[newClassName] = store[className];
+                delete store[className];
+                changed = true;
+            }
+            // Rename parentClass references.
+            for (const entry of Object.values(store)) {
+                if (entry && entry.parentClass === className) {
+                    entry.parentClass = newClassName;
+                    changed = true;
+                }
+            }
+            if (changed) {
+                globalThis.localStorage?.setItem(this.SUPER_CALL_TYPE_HINTS_KEY, JSON.stringify(store));
+            }
         }
     }
 

--- a/custom-generator-codelab/src/utils/LocalStorageManager.js
+++ b/custom-generator-codelab/src/utils/LocalStorageManager.js
@@ -31,6 +31,7 @@ class LocalStorageManager {
         globalThis.localStorage?.setItem(this.CTR_STORAGE_KEY, JSON.stringify({}));
         globalThis.localStorage?.setItem(this.SUPER_CALL_TYPE_HINTS_KEY, JSON.stringify({}));
         globalThis.localStorage?.setItem(this.CONSTRUCTOR_CALLSITE_HINTS_KEY, JSON.stringify({}));
+        globalThis.localStorage?.setItem(this.METHODS_STORAGE_KEY, JSON.stringify({}));
         //console.log("Cleared all stored constructors.");
     }
 

--- a/custom-generator-codelab/src/utils/LocalStorageManager.js
+++ b/custom-generator-codelab/src/utils/LocalStorageManager.js
@@ -2,6 +2,7 @@ class LocalStorageManager {
 
     static WORKSPACE_STORAGE_KEY = '';
     static CTR_STORAGE_KEY = 'constructors';
+    static METHODS_STORAGE_KEY = 'methodDefinitions';
     static JAVA_MODIFIED_KEY_PREFIX  = 'javaModified_';
     static JAVA_GENERATED_KEY_PREFIX = 'javaGenerated_';
     
@@ -50,6 +51,51 @@ class LocalStorageManager {
         return ret;
     }
 
+    // ── Method-definition storage ─────────────────────────────────────────────
+
+    /**
+     * Clears all stored method definitions for className so they can be
+     * re-populated on the next code generation.
+     * @param {string} className
+     */
+    static clearMethods(className) {
+        if (!className) return;
+        const raw = globalThis.localStorage?.getItem(this.METHODS_STORAGE_KEY);
+        const store = JSON.parse(raw) || {};
+        store[className] = [];
+        globalThis.localStorage?.setItem(this.METHODS_STORAGE_KEY, JSON.stringify(store));
+    }
+
+    /**
+     * Removes all stored method definitions for every class.
+     */
+    static clearAllMethods() {
+        globalThis.localStorage?.setItem(this.METHODS_STORAGE_KEY, JSON.stringify({}));
+    }
+
+    /**
+     * Stores a method definition for className.
+     * @param {string} className
+     * @param {{ name: string, arguments: string[], isStatic: boolean, hasReturn: boolean }} methodData
+     */
+    static storeMethods(className, methodData) {
+        if (!className) return;
+        const raw = globalThis.localStorage?.getItem(this.METHODS_STORAGE_KEY);
+        const store = JSON.parse(raw) || {};
+        if (!store[className]) store[className] = [];
+        store[className].push(methodData);
+        globalThis.localStorage?.setItem(this.METHODS_STORAGE_KEY, JSON.stringify(store));
+    }
+
+    /**
+     * Returns all stored method definitions grouped by class name.
+     * @returns {Object.<string, Array<{name:string, arguments:string[], isStatic:boolean, hasReturn:boolean}>>}
+     */
+    static getAllMethods() {
+        const raw = globalThis.localStorage?.getItem(this.METHODS_STORAGE_KEY);
+        return JSON.parse(raw) || {};
+    }
+
     static deleteClass(className) {
         let ctrs = globalThis.localStorage?.getItem(this.CTR_STORAGE_KEY);
         let ctrObjs = JSON.parse(ctrs) || {};
@@ -64,6 +110,8 @@ class LocalStorageManager {
         // Clean up java-modified flag and generated-code cache.
         globalThis.localStorage?.removeItem(this.JAVA_MODIFIED_KEY_PREFIX  + className);
         globalThis.localStorage?.removeItem(this.JAVA_GENERATED_KEY_PREFIX + className);
+        // Clean up stored method definitions.
+        this.clearMethods(className);
     }
 
     static renameClass(className, newClassName) {

--- a/custom-generator-codelab/src/utils/ToolboxConfigManager.js
+++ b/custom-generator-codelab/src/utils/ToolboxConfigManager.js
@@ -132,7 +132,7 @@ export class ToolboxConfigManager {
    */
   static isCategoryActive(categoryName) {
     if (!this.lastConfig?.categories) return true;
-    const entry = this.lastConfig.categories.find(c => c.name === categoryName);
+    const entry = this.lastConfig?.categories?.find(c => c.name === categoryName);
     return !entry || entry.active !== false;
   }
 
@@ -145,7 +145,7 @@ export class ToolboxConfigManager {
    * @param {string|Object|null} configJson – raw JSON string, already-parsed object, or null to reset
    * @param {import('blockly').WorkspaceSvg} workspace
    */
-  static apply(configJson, workspace) {
+  static applyConfig(configJson, workspace) {
     if (!workspace) return;
 
     let config = null;
@@ -212,6 +212,35 @@ export class ToolboxConfigManager {
    * @param {import('blockly').WorkspaceSvg} workspace
    * @param {Object} fallbackConfig – config to show when no custom config is active
    */
+  /**
+   * Builds a full "everything active" preset config from FULL_TOOLBOX.
+   * @param {Object|null} fallbackConfig – used to populate subcategories for dynamic categories
+   * @returns {Object} preset config object
+   */
+  static _buildPresetAlles(fallbackConfig) {
+    const categories = (FULL_TOOLBOX.contents ?? [])
+      .filter(item => item.kind?.toLowerCase() === 'category')
+      .map(cat => {
+        const entry = { name: cat.name, active: true };
+        if (cat.custom) {
+          const fbCat = (fallbackConfig?.categories ?? []).find(c => c.name === cat.name);
+          if (fbCat?.subcategories) {
+            entry.subcategories = fbCat.subcategories.map(s => ({
+              ...s,
+              active: true,
+              ...(s.blocks ? { blocks: s.blocks.map(b => ({ ...b, active: true })) } : {}),
+            }));
+          }
+        } else if (cat.contents?.length) {
+          entry.blocks = cat.contents
+            .filter(b => b.kind?.toLowerCase() === 'block')
+            .map(b => ({ type: b.type, active: true }));
+        }
+        return entry;
+      });
+    return { version: 1, description: 'Alle Blöcke aktiv', categories };
+  }
+
   static openConfigEditor(workspace, fallbackConfig) {
     // Remove any stale dialog.
     document.getElementById('b2j-config-editor-overlay')?.remove();
@@ -259,31 +288,7 @@ export class ToolboxConfigManager {
     Object.assign(presetLabel.style, { fontSize: '11px', opacity: '0.5', marginRight: '2px' });
     presetRow.appendChild(presetLabel);
 
-    const PRESET_ALLES = (() => {
-      // Build a full config from FULL_TOOLBOX with every category/block active.
-      const categories = (FULL_TOOLBOX.contents ?? [])
-        .filter(item => item.kind?.toLowerCase() === 'category')
-        .map(cat => {
-          const entry = { name: cat.name, active: true };
-          if (cat.custom) {
-            // For dynamic categories, derive subcategories from fallbackConfig if present.
-            const fbCat = (fallbackConfig?.categories ?? []).find(c => c.name === cat.name);
-            if (fbCat?.subcategories) {
-              entry.subcategories = fbCat.subcategories.map(s => ({
-                ...s,
-                active: true,
-                ...(s.blocks ? { blocks: s.blocks.map(b => ({ ...b, active: true })) } : {}),
-              }));
-            }
-          } else if (cat.contents?.length) {
-            entry.blocks = cat.contents
-              .filter(b => b.kind?.toLowerCase() === 'block')
-              .map(b => ({ type: b.type, active: true }));
-          }
-          return entry;
-        });
-      return { version: 1, description: 'Alle Blöcke aktiv', categories };
-    })();
+    const PRESET_ALLES = ToolboxConfigManager._buildPresetAlles(fallbackConfig);
 
     function makePresetBtn(label, getJson) {
       const btn = document.createElement('button');
@@ -345,7 +350,7 @@ export class ToolboxConfigManager {
     resetBtn.style.marginRight = 'auto';
     resetBtn.onclick = () => {
       if (!confirm('Toolbox-Konfiguration löschen und vollständige Standard-Toolbox wiederherstellen?')) return;
-      this.apply(null, workspace);
+      this.applyConfig(null, workspace);
       overlay.remove();
     };
 
@@ -362,7 +367,7 @@ export class ToolboxConfigManager {
         errMsg.textContent = 'Ungültiges JSON: ' + e.message;
         return;
       }
-      this.apply(parsed, workspace);
+      this.applyConfig(parsed, workspace);
       overlay.remove();
     };
 

--- a/custom-generator-codelab/src/utils/ToolboxConfigManager.js
+++ b/custom-generator-codelab/src/utils/ToolboxConfigManager.js
@@ -21,9 +21,8 @@
  *       "name": "Variablen",    // dynamic flyout category
  *       "active": true,
  *       "subcategories": [      // controls which sections appear inside the flyout
- *         { "name": "Attribute",           "active": true  },
- *         { "name": "Lokale Variablen",    "active": true  },
- *         { "name": "Statische Attribute", "active": false }
+ *         { "name": "Lokale Variablen",  "active": true  },
+ *         { "name": "Globale Variablen", "active": false }
  *       ]
  *     },
  *     {
@@ -35,7 +34,7 @@
  *       ]
  *     },
  *     {
- *       "name": "Attribute",   // dynamic flyout: normal + static attributes
+ *       "name": "Attribute",    // dynamic flyout category
  *       "active": true,
  *       "subcategories": [
  *         { "name": "Instanz-Attribute",  "active": true },
@@ -43,8 +42,8 @@
  *       ]
  *     },
  *     {
- *       "name": "Parameter",   // dynamic flyout: param blocks grouped by method
- *       "active": true         // false → hide entire category
+ *       "name": "Parameter",    // dynamic flyout: parameter blocks grouped by method
+ *       "active": true          // false → hide entire category
  *     }
  *   ]
  * }
@@ -56,7 +55,7 @@
  *    blocks that are themselves marked "active": true.
  *  - A category entry with a "subcategories" array controls which sections are
  *    rendered inside the flyout of dynamic (custom) categories such as
- *    "Variablen" and "Methoden". Unlisted subcategories default to active.
+ *    "Variablen", "Methoden", and "Attribute". Unlisted subcategories default to active.
  *  - Categories without an entry in the config are shown unchanged (default-on).
  *  - Dynamic categories (those with a "custom" property) support only the
  *    category-level active flag and the subcategories array.

--- a/custom-generator-codelab/src/utils/ToolboxConfigManager.js
+++ b/custom-generator-codelab/src/utils/ToolboxConfigManager.js
@@ -33,6 +33,18 @@
  *         { "name": "Objekt-Methoden",  "active": true  },
  *         { "name": "Klassen-Methoden", "active": false }
  *       ]
+ *     },
+ *     {
+ *       "name": "Attribute",   // dynamic flyout: normal + static attributes
+ *       "active": true,
+ *       "subcategories": [
+ *         { "name": "Instanz-Attribute",  "active": true },
+ *         { "name": "Klassen-Attribute",  "active": true }
+ *       ]
+ *     },
+ *     {
+ *       "name": "Parameter",   // dynamic flyout: param blocks grouped by method
+ *       "active": true         // false → hide entire category
  *     }
  *   ]
  * }
@@ -112,6 +124,20 @@ export class ToolboxConfigManager {
   }
 
   /**
+   * Returns whether the given category is active in the current config.
+   * Defaults to true when the category has no config entry or when no config
+   * is loaded at all (= full toolbox).
+   *
+   * @param {string} categoryName
+   * @returns {boolean}
+   */
+  static isCategoryActive(categoryName) {
+    if (!this.lastConfig?.categories) return true;
+    const entry = this.lastConfig.categories.find(c => c.name === categoryName);
+    return !entry || entry.active !== false;
+  }
+
+  /**
    * Parses `configJson` and updates the toolbox on the given Blockly workspace.
    *
    * Passing `null` / `undefined` resets the toolbox to the full default toolbox
@@ -178,6 +204,178 @@ export class ToolboxConfigManager {
     } catch (err) {
       console.warn('[ToolboxConfigManager] updateToolbox failed:', err);
     }
+  }
+
+  /**
+   * Opens a modal dialog that lets the user view and edit the current toolbox
+   * config JSON. On save the new config is applied immediately.
+   *
+   * @param {import('blockly').WorkspaceSvg} workspace
+   * @param {Object} fallbackConfig – config to show when no custom config is active
+   */
+  static openConfigEditor(workspace, fallbackConfig) {
+    // Remove any stale dialog.
+    document.getElementById('b2j-config-editor-overlay')?.remove();
+
+    const currentJson = this.lastConfig
+      ? JSON.stringify(this.lastConfig, null, 2)
+      : JSON.stringify(fallbackConfig ?? {}, null, 2);
+
+    // ── Overlay ──────────────────────────────────────────────────────────
+    const overlay = document.createElement('div');
+    overlay.id = 'b2j-config-editor-overlay';
+    Object.assign(overlay.style, {
+      position: 'fixed', inset: '0', zIndex: '9999',
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      background: 'rgba(0,0,0,0.55)',
+    });
+
+    // ── Dialog box ───────────────────────────────────────────────────────
+    const box = document.createElement('div');
+    Object.assign(box.style, {
+      background: '#252526', color: '#d4d4d4',
+      border: '1px solid #3c3c3c', borderRadius: '6px',
+      padding: '14px 16px 12px', width: 'min(640px, 90vw)',
+      maxHeight: '80vh', display: 'flex', flexDirection: 'column',
+      gap: '10px', fontFamily: 'Consolas, monospace', fontSize: '12px',
+      boxShadow: '0 8px 32px rgba(0,0,0,0.6)',
+    });
+
+    const title = document.createElement('div');
+    title.textContent = 'Toolbox-Konfiguration';
+    Object.assign(title.style, {
+      font: '600 12px Roboto, sans-serif', letterSpacing: '0.05em',
+      textTransform: 'uppercase', opacity: '0.55', flexShrink: '0',
+    });
+    box.appendChild(title);
+
+    // ── Preset shortcuts ─────────────────────────────────────────────────
+    const presetRow = document.createElement('div');
+    Object.assign(presetRow.style, {
+      display: 'flex', alignItems: 'center', gap: '6px',
+      flexShrink: '0', fontFamily: 'Roboto, sans-serif',
+    });
+    const presetLabel = document.createElement('span');
+    presetLabel.textContent = 'Vorlage:';
+    Object.assign(presetLabel.style, { fontSize: '11px', opacity: '0.5', marginRight: '2px' });
+    presetRow.appendChild(presetLabel);
+
+    const PRESET_ALLES = (() => {
+      // Build a full config from FULL_TOOLBOX with every category/block active.
+      const categories = (FULL_TOOLBOX.contents ?? [])
+        .filter(item => item.kind?.toLowerCase() === 'category')
+        .map(cat => {
+          const entry = { name: cat.name, active: true };
+          if (cat.custom) {
+            // For dynamic categories, derive subcategories from fallbackConfig if present.
+            const fbCat = (fallbackConfig?.categories ?? []).find(c => c.name === cat.name);
+            if (fbCat?.subcategories) {
+              entry.subcategories = fbCat.subcategories.map(s => ({
+                ...s,
+                active: true,
+                ...(s.blocks ? { blocks: s.blocks.map(b => ({ ...b, active: true })) } : {}),
+              }));
+            }
+          } else if (cat.contents?.length) {
+            entry.blocks = cat.contents
+              .filter(b => b.kind?.toLowerCase() === 'block')
+              .map(b => ({ type: b.type, active: true }));
+          }
+          return entry;
+        });
+      return { version: 1, description: 'Alle Blöcke aktiv', categories };
+    })();
+
+    function makePresetBtn(label, getJson) {
+      const btn = document.createElement('button');
+      btn.textContent = label;
+      Object.assign(btn.style, {
+        padding: '3px 10px', border: '1px solid #4a4a4a',
+        borderRadius: '3px', background: '#333', color: '#bbb',
+        cursor: 'pointer', fontSize: '11px', fontFamily: 'Roboto, sans-serif',
+      });
+      btn.addEventListener('mouseenter', () => btn.style.background = '#404040');
+      btn.addEventListener('mouseleave', () => btn.style.background = '#333');
+      btn.onclick = () => { textarea.value = JSON.stringify(getJson(), null, 2); };
+      return btn;
+    }
+
+    presetRow.appendChild(makePresetBtn('Alles', () => PRESET_ALLES));
+    presetRow.appendChild(makePresetBtn('9. Klasse', () => fallbackConfig ?? PRESET_ALLES));
+    box.appendChild(presetRow);
+
+    const textarea = document.createElement('textarea');
+    textarea.value = currentJson;
+    textarea.spellcheck = false;
+    Object.assign(textarea.style, {
+      flex: '1', minHeight: '300px', maxHeight: '55vh',
+      background: '#1c1c1c', color: '#d4d4d4',
+      border: '1px solid #3c3c3c', borderRadius: '4px',
+      padding: '8px', resize: 'vertical', outline: 'none',
+      fontFamily: 'Consolas, monospace', fontSize: '12px',
+      lineHeight: '1.5', tabSize: '2',
+    });
+    box.appendChild(textarea);
+
+    const errMsg = document.createElement('div');
+    Object.assign(errMsg.style, {
+      color: '#f48771', fontSize: '11px', minHeight: '14px',
+      fontFamily: 'Roboto, sans-serif', flexShrink: '0',
+    });
+    box.appendChild(errMsg);
+
+    // ── Buttons ───────────────────────────────────────────────────────────
+    const btnRow = document.createElement('div');
+    Object.assign(btnRow.style, {
+      display: 'flex', gap: '8px', justifyContent: 'flex-end', flexShrink: '0',
+    });
+
+    function makeBtn(label, bg) {
+      const btn = document.createElement('button');
+      btn.textContent = label;
+      Object.assign(btn.style, {
+        padding: '5px 14px', border: '1px solid #555',
+        borderRadius: '4px', background: bg, color: '#d4d4d4',
+        cursor: 'pointer', fontSize: '12px', fontFamily: 'Roboto, sans-serif',
+      });
+      return btn;
+    }
+
+    const resetBtn = makeBtn('Zurücksetzen', '#3a3a3a');
+    resetBtn.title = 'Konfiguration löschen und Standard-Toolbox wiederherstellen';
+    resetBtn.style.marginRight = 'auto';
+    resetBtn.onclick = () => {
+      if (!confirm('Toolbox-Konfiguration löschen und vollständige Standard-Toolbox wiederherstellen?')) return;
+      this.apply(null, workspace);
+      overlay.remove();
+    };
+
+    const cancelBtn = makeBtn('Abbrechen', '#3a3a3a');
+    cancelBtn.onclick = () => overlay.remove();
+
+    const saveBtn = makeBtn('Speichern', '#0e639c');
+    saveBtn.style.border = '1px solid #1177bb';
+    saveBtn.onclick = () => {
+      let parsed;
+      try {
+        parsed = JSON.parse(textarea.value);
+      } catch (e) {
+        errMsg.textContent = 'Ungültiges JSON: ' + e.message;
+        return;
+      }
+      this.apply(parsed, workspace);
+      overlay.remove();
+    };
+
+    btnRow.appendChild(resetBtn);
+    btnRow.appendChild(cancelBtn);
+    btnRow.appendChild(saveBtn);
+    box.appendChild(btnRow);
+
+    overlay.appendChild(box);
+    overlay.addEventListener('click', (e) => { if (e.target === overlay) overlay.remove(); });
+    document.body.appendChild(overlay);
+    textarea.focus();
   }
 
   /**

--- a/custom-generator-codelab/src/utils/WorkspaceManager.js
+++ b/custom-generator-codelab/src/utils/WorkspaceManager.js
@@ -147,10 +147,20 @@ export const FULL_ACTIVE_CONFIG = {
       name: 'Variablen',
       active: true,
       subcategories: [
-        { name: 'Lokale Variablen',    active: true },
-        { name: 'Attribute',           active: true },
-        { name: 'Statische Attribute', active: true },
+        { name: 'Lokale Variablen', active: true },
       ],
+    },
+    {
+      name: 'Attribute',
+      active: true,
+      subcategories: [
+        { name: 'Instanz-Attribute', active: true },
+        { name: 'Klassen-Attribute', active: true },
+      ],
+    },
+    {
+      name: 'Parameter',
+      active: true,
     },
     {
       name: 'Methoden',

--- a/custom-generator-codelab/src/utils/WorkspaceManager.js
+++ b/custom-generator-codelab/src/utils/WorkspaceManager.js
@@ -231,7 +231,7 @@ export class WorkspaceManager {
 
     // Apply the full-active config so the blank workspace has an explicit
     // blockly-config.json (all categories on) rather than implicit defaults.
-    ToolboxConfigManager.apply(FULL_ACTIVE_CONFIG, ws);
+    ToolboxConfigManager.applyConfig(FULL_ACTIVE_CONFIG, ws);
 
     // ── 2. Disconnect git ────────────────────────────────────────────────
     GitService.clearConfig();
@@ -516,7 +516,7 @@ export class WorkspaceManager {
     }
 
     // ── Apply toolbox config (resets to full toolbox if absent) ----------
-    ToolboxConfigManager.apply(toolboxConfig, ws);
+    ToolboxConfigManager.applyConfig(toolboxConfig, ws);
 
     // ── Reload Blockly for the active file -------------------------------
     const activeFile = IdeBridge.selected_file_name;

--- a/custom-generator-codelab/src/utils/WorkspaceManager.js
+++ b/custom-generator-codelab/src/utils/WorkspaceManager.js
@@ -180,6 +180,8 @@ export const FULL_ACTIVE_CONFIG = {
       blocks: [
         { type: 'defconstructor',  active: true },
         { type: 'callconstructor', active: true },
+        { type: 'java_extends',    active: true },
+        { type: 'java_super_call', active: true },
       ],
     },
   ],


### PR DESCRIPTION
Introduce support for inheritance in the code generation process by adding `java_extends` and `java_super_call` blocks. This enhancement allows users to define parent classes and invoke super constructors, improving the object-oriented capabilities of the framework. Additionally, methods from parent classes are now accessible in the workspace.

closes #36