### PR TITLE
Implement file selection persistence in Online-IDE

### DIFF
--- a/custom-generator-codelab/src/index.js
+++ b/custom-generator-codelab/src/index.js
@@ -61,6 +61,19 @@ function init() {
   ToolboxConfigManager.applyConfig(storedToolboxConfig ?? FULL_ACTIVE_CONFIG, ws);
 
   // Load the initial state from storage and run the code.
+  // Restore previously selected IDE file (if any) so a refresh keeps selection.
+  try {
+    const stored = globalThis.localStorage?.getItem('b2j.selected_file_name');
+    const lastJava = globalThis.localStorage?.getItem('b2j.last_java_file_name');
+    if (stored) {
+      IdeBridge.selected_file_name = stored;
+      if (stored.endsWith('.java')) IdeBridge.last_java_file_name = stored;
+    } else if (lastJava) {
+      IdeBridge.last_java_file_name = lastJava;
+    }
+  } catch (e) {
+    // ignore storage errors
+  }
   load(ws);
   //onBlocksChange();
 
@@ -137,10 +150,31 @@ function setupListeners(workspace) {
       this._online_ide_access = value;
       const ideAccess = value?.getIDE?.('Java');
       if (ideAccess) {
+        // Store a direct reference on IdeBridge so it can drive IDE selection.
+        IdeBridge.ideAccess = ideAccess;
+
         ideAccess.onFileRenamed( (prev, next) => IdeBridge.filenameChanged(prev, next));
         ideAccess.onFileDeleted( (name)       => IdeBridge.fileDeleted(name));
         ideAccess.onFileCreated( (name)       => IdeBridge.fileCreated(name));
-        ideAccess.onFileSelected((name)       => IdeBridge.fileSelected(name));
+
+        // Intercept the IDE's initial auto-selection: if it picks a different
+        // file than what was active before the page refresh, override it once.
+        const storedFile = globalThis.localStorage?.getItem('b2j.selected_file_name') ?? '';
+        let _initialSelectionHandled = !storedFile; // skip intercept if nothing stored
+        ideAccess.onFileSelected((name) => {
+          if (!_initialSelectionHandled) {
+            _initialSelectionHandled = true;
+            if (name !== storedFile) {
+              // The IDE auto-selected the wrong file — drive it to the right one.
+              // IdeBridge.selectFileInIDE will call selectFile() without a
+              // suppression flag, which makes the IDE fire onFileSelected again
+              // with storedFile so the workspace loads correctly.
+              IdeBridge.selectFileInIDE(storedFile);
+              return; // discard this event for the wrong file
+            }
+          }
+          IdeBridge.fileSelected(name);
+        });
 
         // ── Java-modified detection polling ───────────────────────────
         // Poll every 350 ms to compare the IDE's current code against the

--- a/custom-generator-codelab/src/utils/IdeBridge.js
+++ b/custom-generator-codelab/src/utils/IdeBridge.js
@@ -15,6 +15,55 @@ export class IdeBridge {
    */
   static last_java_file_name = '';
 
+  /**
+   * Direct reference to the Online-IDE Java IDE access object.
+   * Set once from index.js when online_ide_access is first assigned.
+   * Enables B2J to actively drive file selection in the IDE.
+   */
+  static ideAccess = null;
+
+  /**
+   * Programmatically selects a file in the Online-IDE file explorer.
+   * Triggers the IDE's own onFileSelected callback so IdeBridge.fileSelected
+   * is called and loads the corresponding Blockly workspace.
+   * @param {string} fileName  e.g. 'Foo.java'
+   * @returns {boolean} true if the file was found and selected
+   */
+  static selectFileInIDE(fileName) {
+    const ideAccess = this.ideAccess;
+    if (!ideAccess) { 
+      return false;
+    }
+    const wrappedFiles = ideAccess.getFiles?.() ?? [];
+    const wrapped = wrappedFiles.find(f => f.getName?.() === fileName);
+    if (!wrapped) {
+      return false;
+    }
+    const internalFile = wrapped.file ?? wrapped;
+    try {
+      const treeview = ideAccess.ide?.fileExplorer?.treeview;
+      if (treeview) {
+        // Clear every currently highlighted node first so we don't end up
+        // with two files selected at once.
+        treeview.unselectAllNodes(false);
+        // Select the target node. invokeCallback=true fires the IDE's internal
+        // nodeClickedCallback → selectFile + notifyFileSelected → our
+        // onFileSelected wrapper → IdeBridge.fileSelected loads the workspace.
+        const node = treeview.nodes?.find(n => n.externalObject === internalFile);
+        if (node) {
+          treeview.selectNodeAndSetFocus(node, true);
+          return true;
+        }
+      }
+      // Fallback when the treeview isn't available yet.
+      ideAccess.ide?.fileExplorer?.selectFile?.(internalFile);
+    } catch (e) {
+      // If the IDE API fails, update IdeBridge state directly as a fallback.
+      this.fileSelected(fileName);
+    }
+    return true;
+  }
+
   static syncClassNameFromIDE() {
     let className = '';
     const fileName = this.selected_file_name;
@@ -125,6 +174,10 @@ export class IdeBridge {
     // (bypassing the setter so we don't trigger a reload) and sync the class name.
     if (this.selected_file_name === previousName) {
       this.selected_file_name = newName;
+      try {
+        globalThis.localStorage?.setItem('b2j.selected_file_name', newName);
+        globalThis.localStorage?.setItem('b2j.last_java_file_name', newName);
+      } catch (e) {}
       this.syncClassNameFromIDE();
     }
   }
@@ -145,6 +198,7 @@ export class IdeBridge {
     // If the deleted file was currently active, clear the Blockly workspace.
     if (this.selected_file_name === fileName) {
       this.selected_file_name = '';
+      try { globalThis.localStorage?.removeItem('b2j.selected_file_name'); } catch (e) {}
       Blockly.getMainWorkspace()?.clear();
       this.syncClassNameFromIDE();
     }
@@ -185,6 +239,14 @@ export class IdeBridge {
 
     // Update the plain global property so save/load use the correct storage key.
     this.selected_file_name = fileName;
+    try {
+      globalThis.localStorage?.setItem('b2j.selected_file_name', fileName);
+      if (fileName.endsWith('.java')) {
+        globalThis.localStorage?.setItem('b2j.last_java_file_name', fileName);
+      }
+    } catch (e) {
+      // ignore storage errors
+    }
     if (fileName.endsWith('.java')) {
       this.last_java_file_name = fileName;
     }


### PR DESCRIPTION
Introduce functionality to persist file selection in the Online-IDE, allowing users to maintain their selected file across page refreshes. This includes storing the selected file name in local storage and restoring it upon initialization. Additionally, the IDE's file selection behavior is adjusted to ensure the correct file is selected after a refresh.