### PR TITLE
Fix default username in GitService clone method

### DIFF
--- a/custom-generator-codelab/src/utils/GitService.js
+++ b/custom-generator-codelab/src/utils/GitService.js
@@ -207,7 +207,7 @@ export class GitService {
   static async clone(rawUrl, password) {
     const { url, username, password: urlPassword } = this.parseGitUrl(rawUrl);
     const finalPassword = urlPassword || password || '';
-    const finalUsername  = username || 'git';
+    const finalUsername  = username || '';
 
     const fs = this._getFs();
 


### PR DESCRIPTION
Update the default username in the GitService clone method to be empty instead of 'git' when no username is provided.