### PR TITLE
Implement custom loop block with local variable support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,19 +11,7 @@
             "url": "http://localhost:8080",
             "webRoot": "${workspaceFolder}/custom-generator-codelab",
             "preLaunchTask": "npmstart",
-            "sourceMapPathOverrides": {
-                "webpack://custom-generator-codelab/./src/*": "${webRoot}/src/*",
-                "webpack://custom-generator-codelab/*": "${webRoot}/*",
-                "webpack:///*": "${webRoot}/*"
-            }
-        },
-        {
-            "type": "chrome",
-            "request": "launch",
-            "name": "Debug B2J with Chrome (no IDE rebuild)",
-            "url": "http://localhost:8080",
-            "webRoot": "${workspaceFolder}/custom-generator-codelab",
-            "preLaunchTask": "npmstart-no-rebuild",
+            "postDebugTask": "npmstop",
             "sourceMapPathOverrides": {
                 "webpack://custom-generator-codelab/./src/*": "${webRoot}/src/*",
                 "webpack://custom-generator-codelab/*": "${webRoot}/*",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,51 +1,36 @@
 {
-    "version": "2.0.0",
-    "tasks": [
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "npmstart",
+      "type": "shell",
+      "command": "npm start",
+      "options": { "cwd": "${workspaceFolder}/custom-generator-codelab" },
+      "isBackground": true,
+      "problemMatcher": [
         {
-            "label": "npmstart",
-            "type": "shell",
-            "command": "npm run dev",
-            "options": {
-                "cwd": "${workspaceFolder}"
-            },
-            "isBackground": true,
-            "problemMatcher": {
-                "pattern": {
-                    "regexp": "^$"
-                },
-                "background": {
-                    "activeOnStart": true,
-                    "beginsPattern": ".*",
-                    "endsPattern": "(webpack.*compiled|Compiled successfully)"
-                }
-            },
-            "presentation": {
-                "reveal": "always",
-                "panel": "new"
+          "pattern": [
+            {
+              "regexp": "^(?:)$",
+              "file": 1,
+              "location": 2,
+              "message": 3
             }
-        },
-        {
-            "label": "npmstart-no-rebuild",
-            "type": "shell",
-            "command": "npm start",
-            "options": {
-                "cwd": "${workspaceFolder}/custom-generator-codelab"
-            },
-            "isBackground": true,
-            "problemMatcher": {
-                "pattern": {
-                    "regexp": "^$"
-                },
-                "background": {
-                    "activeOnStart": true,
-                    "beginsPattern": ".*",
-                    "endsPattern": "(webpack.*compiled|Compiled successfully)"
-                }
-            },
-            "presentation": {
-                "reveal": "always",
-                "panel": "new"
-            }
+          ],
+          "background": {
+                "activeOnStart": true,
+                "beginsPattern": "Serving!",
+                "endsPattern": "Copied local address to clipboard!"
+        }   
         }
-    ]
+      ],
+      "presentation": { "reveal": "always", "panel": "shared" }
+    },
+    {
+      "label": "npmstop",
+      "type": "shell",
+      "command": "fuser -k 8080/tcp || pkill -f custom-generator-codelab || true",
+      "presentation": { "reveal": "always", "panel": "shared" }
+    }
+  ]
 }

--- a/custom-generator-codelab/src/blocks/custom_loops.js
+++ b/custom-generator-codelab/src/blocks/custom_loops.js
@@ -1,0 +1,27 @@
+/**
+ * Custom override for the repeat block to expose the iteration variable
+ * as a selectable `FieldVariable` of type 'local'. This makes the loop
+ * counter accessible to `java_local_var_get` blocks.
+ */
+import * as Blockly from 'blockly/core';
+
+Blockly.Blocks['controls_repeat_ext'] = {
+  init: function() {
+    this.appendDummyInput()
+        .appendField('repeat')
+        .appendField(new Blockly.FieldVariable('i', null, ['local'], 'local'), 'VAR');
+    this.appendValueInput('TIMES')
+        .setCheck('Number');
+    this.appendDummyInput()
+        .appendField('times');
+    this.appendStatementInput('DO')
+        .setCheck(null);
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(120);
+    this.setTooltip('Repeat n times. Iteration variable is a local variable.');
+  }
+};
+
+// Also expose short name alias to preserve existing references
+Blockly.Blocks['controls_repeat'] = Blockly.Blocks['controls_repeat_ext'];

--- a/custom-generator-codelab/src/blocks/custom_loops.js
+++ b/custom-generator-codelab/src/blocks/custom_loops.js
@@ -7,9 +7,16 @@ import * as Blockly from 'blockly/core';
 
 Blockly.Blocks['controls_repeat_ext'] = {
   init: function() {
+    // Generate a unique default name for the loop counter variable in this workspace.
+    const workspace = this.workspace || null;
+    let defaultName = 'i';
+    if (workspace && Blockly.Variables && typeof Blockly.Variables.generateUniqueName === 'function') {
+      defaultName = Blockly.Variables.generateUniqueName(workspace);
+    }
+
     this.appendDummyInput()
         .appendField('repeat')
-        .appendField(new Blockly.FieldVariable('i', null, ['local'], 'local'), 'VAR');
+        .appendField(new Blockly.FieldVariable(defaultName, null, ['local'], 'local'), 'VAR');
     this.appendValueInput('TIMES')
         .setCheck('Number');
     this.appendDummyInput()

--- a/custom-generator-codelab/src/generators/javascript/loops.js
+++ b/custom-generator-codelab/src/generators/javascript/loops.js
@@ -13,7 +13,7 @@
 import * as Blockly from 'blockly/core';
 // import * as stringUtils from 'blockly/core/utils/string.js';
 // import {NameType} from 'blockly/core/names.js';
-import {Order, adjustStaticName} from './javascript_generator.js';
+import {Order, adjustStaticName, getVarCodeName} from './javascript_generator.js';
 
 
 export function controls_repeat_ext(block, generator) {
@@ -29,7 +29,17 @@ export function controls_repeat_ext(block, generator) {
   let branch = generator.statementToCode(block, 'DO');
   branch = generator.addLoopTrap(branch, block);
   let code = '';
-  const loopVar = generator.nameDB_.getDistinctName('i', Blockly.Names.NameType.VARIABLE);
+  // Prefer an explicit variable field on the block (our custom override).
+  const varFieldId = block.getFieldValue && block.getFieldValue('VAR');
+  let loopVar;
+  if (varFieldId) {
+    // Mark this variable id as declared so other generators don't redeclare it.
+    if (!generator.declaredLocalVarIds_) generator.declaredLocalVarIds_ = new Set();
+    try { generator.declaredLocalVarIds_.add(varFieldId); } catch (e) { /* ignore */ }
+    loopVar = adjustStaticName(getVarCodeName(block.workspace, generator, varFieldId));
+  } else {
+    loopVar = generator.nameDB_.getDistinctName('i', Blockly.Names.NameType.VARIABLE);
+  }
   let endVar = repeats;
   if (!repeats.match(/^\w+$/) && !Blockly.utils.string.isNumber(repeats)) {
     endVar = generator.nameDB_.getDistinctName('repeat_end', Blockly.Names.NameType.VARIABLE);

--- a/custom-generator-codelab/src/index.js
+++ b/custom-generator-codelab/src/index.js
@@ -14,6 +14,7 @@ import './blocks/java_method_blocks.js';
 import './blocks/java_object_call_blocks.js';
 import './blocks/java_graphics_blocks.js';
 import './blocks/text.js';
+import './blocks/custom_loops.js';
 import {getClassName, setClassName} from "./generators/javascript/javascript_generator";
 import LocalStorageManager from "./utils/LocalStorageManager.js";
 
@@ -79,6 +80,9 @@ function init() {
     // ignore storage errors
   }
   load(ws);
+  // Ensure existing for-loop variables are typed as local so they are
+  // available to `java_local_var_*` blocks.
+  ensureForLoopVarsAreLocal(ws);
   //onBlocksChange();
 
   // Initialise the overlay manager that guards Blockly when Java was manually edited.
@@ -133,6 +137,57 @@ function setupBlockly(theme) {
 }
 
 /**
+ * Ensure that all `controls_for` loop iteration variables are created as
+ * Java-local variables (type 'local') so they appear in the `java_local_var_*`
+ * variable blocks and behave like normal local variables.
+ */
+function ensureForLoopVarsAreLocal(workspace) {
+  try {
+    const forBlocks = [
+      ...workspace.getBlocksByType('controls_for', true) || [],
+      ...workspace.getBlocksByType('controls_forEach', true) || [],
+      ...workspace.getBlocksByType('controls_repeat_ext', true) || [],
+    ];
+    for (const b of forBlocks) {
+      const field = b.getField && b.getField('VAR');
+      if (!field) continue;
+      const oldId = field.getValue();
+      if (!oldId) continue;
+      const oldVar = workspace.getVariableById(oldId);
+      if (!oldVar) continue;
+      if (oldVar.type === 'local') continue; // already correct
+
+      // Create or lookup a variable with the same name but type 'local'.
+      const newVar = Blockly.Variables.getOrCreateVariablePackage(
+        workspace,
+        null,
+        oldVar.name,
+        'local',
+      );
+      const newId = newVar.getId();
+      if (newId === oldId) {
+        // If the id is identical, just ensure the field uses it (safe noop).
+        field.setValue(newId);
+        continue;
+      }
+
+      // Replace all references to the old variable id with the new id.
+      const all = workspace.getAllBlocks(false);
+      for (const blk of all) {
+        if (typeof blk.renameVarById === 'function') {
+          try { blk.renameVarById(oldId, newId); } catch (e) { /* ignore */ }
+        }
+      }
+
+      // Remove the old variable (no longer referenced).
+      try { workspace.deleteVariableById(oldId); } catch (e) { /* ignore */ }
+    }
+  } catch (e) {
+    console.warn('ensureForLoopVarsAreLocal failed', e);
+  }
+}
+
+/**
  * Registers all workspace event listeners and the `online_ide_access` and
  * `selected_file_name` property hooks on `globalThis`.
  * @param {Blockly.WorkspaceSvg} workspace
@@ -142,6 +197,14 @@ function setupListeners(workspace) {
   workspace.addChangeListener((e) => {
     if (e.isUiEvent) return;   // scrolling, zooming, etc. — skip
     save(workspace);
+  });
+
+  // When blocks are created (e.g. the user drops a new for-loop), ensure the
+  // loop iteration variable is converted to a typed local variable.
+  workspace.addChangeListener((e) => {
+    if (e.type === Blockly.Events.BLOCK_CREATE || e.type === 'create') {
+      ensureForLoopVarsAreLocal(workspace);
+    }
   });
 
   // Intercept assignments to globalThis.online_ide_access.

--- a/custom-generator-codelab/src/index.js
+++ b/custom-generator-codelab/src/index.js
@@ -169,6 +169,22 @@ function ensureForLoopVarsAreLocal(workspace) {
       const newId = newVar.getId();
       // Point this loop block's VAR field at the fresh local variable.
       field.setValue(newId);
+      // If the old variable is now unused anywhere, remove it to avoid
+      // leaving a duplicate attribute variable behind.
+      try {
+        const remaining = workspace.getVariableUsesById(oldId) || [];
+        if (remaining.length === 0) {
+          if (workspace.variableMap && typeof workspace.variableMap.deleteVariable === 'function') {
+            workspace.variableMap.deleteVariable(oldVar);
+          } else {
+            // Fallback: best-effort deletion.
+            workspace.deleteVariableById(oldId);
+          }
+        }
+      } catch (err) {
+        // Non-fatal — leave the old variable alone if deletion fails.
+        console.debug('Could not remove old loop variable', err);
+      }
     }
   } catch (e) {
     console.warn('ensureForLoopVarsAreLocal failed', e);

--- a/custom-generator-codelab/src/index.js
+++ b/custom-generator-codelab/src/index.js
@@ -157,30 +157,18 @@ function ensureForLoopVarsAreLocal(workspace) {
       if (!oldVar) continue;
       if (oldVar.type === 'local') continue; // already correct
 
-      // Create or lookup a variable with the same name but type 'local'.
-      const newVar = Blockly.Variables.getOrCreateVariablePackage(
-        workspace,
-        null,
-        oldVar.name,
-        'local',
-      );
+      // Create a fresh local variable for the loop counter, ensuring a distinct name.
+      const baseName = oldVar.name || 'i';
+      let newName = baseName;
+      let suffix = 1;
+      // Ensure we don't collide with an existing local variable of the same name.
+      while (workspace.getVariable(newName, 'local')) {
+        newName = `${baseName}_${suffix++}`;
+      }
+      const newVar = workspace.createVariable(newName, 'local');
       const newId = newVar.getId();
-      if (newId === oldId) {
-        // If the id is identical, just ensure the field uses it (safe noop).
-        field.setValue(newId);
-        continue;
-      }
-
-      // Replace all references to the old variable id with the new id.
-      const all = workspace.getAllBlocks(false);
-      for (const blk of all) {
-        if (typeof blk.renameVarById === 'function') {
-          try { blk.renameVarById(oldId, newId); } catch (e) { /* ignore */ }
-        }
-      }
-
-      // Remove the old variable (no longer referenced).
-      try { workspace.deleteVariableById(oldId); } catch (e) { /* ignore */ }
+      // Point this loop block's VAR field at the fresh local variable.
+      field.setValue(newId);
     }
   } catch (e) {
     console.warn('ensureForLoopVarsAreLocal failed', e);

--- a/custom-generator-codelab/src/index.js
+++ b/custom-generator-codelab/src/index.js
@@ -189,10 +189,34 @@ function setupListeners(workspace) {
 
   // When blocks are created (e.g. the user drops a new for-loop), ensure the
   // loop iteration variable is converted to a typed local variable.
+  // Also handle changes to the loop variable field so the invariant is maintained
+  // if the user reassigns the VAR field to a non-local variable.
   workspace.addChangeListener((e) => {
+    // Handle initial creation of loop blocks.
     if (e.type === Blockly.Events.BLOCK_CREATE || e.type === 'create') {
       ensureForLoopVarsAreLocal(workspace);
+      return;
     }
+
+    // Handle changes to the VAR field on existing loop blocks.
+    const isBlockChange =
+      e.type === Blockly.Events.BLOCK_CHANGE || e.type === 'change';
+    if (!isBlockChange) return;
+
+    if (e.element !== 'field' || e.name !== 'VAR' || !e.blockId) return;
+
+    const block = workspace.getBlockById(e.blockId);
+    if (!block) return;
+
+    // Only react for loop blocks that use a VAR field as their iteration variable.
+    const loopTypes = new Set([
+      'controls_for',
+      'controls_forEach',
+      'controls_repeat_ext',
+    ]);
+    if (!loopTypes.has(block.type)) return;
+
+    ensureForLoopVarsAreLocal(workspace);
   });
 
   // Intercept assignments to globalThis.online_ide_access.


### PR DESCRIPTION
Introduce a custom loop block that allows the iteration variable to be a local variable, enhancing accessibility for local variable operations. Additionally, ensure existing for-loop variables are converted to local variables upon creation.

closes #98