### PR TITLE
Fix CORS issue causing 404 errors when cloning

### DIFF
--- a/.github/workflows/deploy_docker.yml
+++ b/.github/workflows/deploy_docker.yml
@@ -20,6 +20,7 @@ jobs:
       
     env:
       DOCKER_REGISTRY: ${{ vars.DOCKER_REGISTRY }}
+      CORS_PROXY_URL: ${{ secrets.CORS_PROXY_URL }}
 
     steps:
       - name: Check out code
@@ -41,14 +42,19 @@ jobs:
           set -e
           REGISTRY="${{ vars.DOCKER_REGISTRY }}"
           IMAGE_NAME="${{ vars.DOCKER_IMAGE }}"
+          CORS_PROXY_URL="${CORS_PROXY_URL}"
           OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
           if [ -z "$REGISTRY" ] || [ -z "$IMAGE_NAME" ]; then
             echo "ERROR: DOCKER_REGISTRY and DOCKER_IMAGE vars must be set" >&2
             exit 1
           fi
+          if [ -z "$CORS_PROXY_URL" ]; then
+            echo "ERROR: secret CORS_PROXY_URL must be set for Docker deployments" >&2
+            exit 1
+          fi
           FULL_IMAGE="$REGISTRY/$OWNER/$IMAGE_NAME:${{ github.sha }}"
           TMP_IMAGE="$REGISTRY/$OWNER/$IMAGE_NAME:dev"
-          DOCKER_BUILDKIT=1 docker build --pull --no-cache --build-arg SKIP_ONLINE_IDE_BUILD=1 -t "$FULL_IMAGE" -t "$TMP_IMAGE" .
+          DOCKER_BUILDKIT=1 docker build --pull --no-cache --build-arg SKIP_ONLINE_IDE_BUILD=1 --build-arg CORS_PROXY_URL="$CORS_PROXY_URL" -t "$FULL_IMAGE" -t "$TMP_IMAGE" .
           docker push "$FULL_IMAGE"
           docker push "$TMP_IMAGE"
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -17,6 +17,7 @@ Required repository secrets (add under Settings → Secrets):
 - `DEPLOY_CONTAINER_NAME` — name of the container to run on the server
 - `DEPLOY_APP_PORT` — internal host port to bind the container to (default: `3000`)
 - `DEPLOY_SERVER_NAME` — nginx `server_name` to use for the site (e.g. `example.com`). If empty, nginx will use the default server.
+- `CORS_PROXY_URL` — absolute URL of the deployed CORS proxy worker used for browser-side git operations (required for production builds)
 
 Optional HTTPS secrets
 - `DEPLOY_ENABLE_HTTPS` — set to `true` to attempt obtaining TLS certs via `certbot`

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,16 @@ COPY . .
 # Remove any pre-existing build artifacts from the repository to force a fresh build
 # If SKIP_ONLINE_IDE_BUILD is set, assume a prebuilt `build/` may be supplied and keep it
 ARG SKIP_ONLINE_IDE_BUILD=0
-RUN if [ "$SKIP_ONLINE_IDE_BUILD" = "1" ]; then echo "Keeping existing custom-generator-codelab/build (SKIP_ONLINE_IDE_BUILD=1)"; else rm -rf custom-generator-codelab/build || true; fi
+ARG CORS_PROXY_URL=
+RUN if [ "$SKIP_ONLINE_IDE_BUILD" = "1" ]; then \
+            echo "Keeping existing custom-generator-codelab/build (SKIP_ONLINE_IDE_BUILD=1)"; \
+        else \
+            rm -rf custom-generator-codelab/build || true; \
+        fi
 # Ensure project files are writable for any npm scripts that create node_modules or artifacts
 RUN chmod -R a+rwX /app || true
 ENV NODE_OPTIONS=--max_old_space_size=2048
+ENV CORS_PROXY_URL=$CORS_PROXY_URL
 RUN npm run build
 
 # Normalize build output: webpack production outputs to `dist`, but the runtime

--- a/README.MD
+++ b/README.MD
@@ -423,7 +423,7 @@ npm run setup
 **Solution:**
 The standalone version saves to cookies. If translation bugs occur (no Java code displayed), clear browser cookies for the domain:
 1. Open browser DevTools → Application → Cookies
-2. Delete all cookies for `b2j.valentin-herrmann.com`
+2. Delete all cookies for `blockly2java.de`
 3. Reload the page
 
 ---

--- a/custom-generator-codelab/SETUP.md
+++ b/custom-generator-codelab/SETUP.md
@@ -114,7 +114,7 @@ To deploy manually, go to the Actions tab on GitHub and trigger the "Build and D
 
 ### Custom Domain
 
-The project is configured to use `b2j.valentin-herrmann.com` as a custom domain. The `CNAME` file is automatically copied to the build output.
+The project is configured to use `blockly2java.de` as a custom domain. The `CNAME` file is automatically copied to the build output.
 
 ## Development Workflow
 

--- a/custom-generator-codelab/cors-proxy-worker/wrangler.toml
+++ b/custom-generator-codelab/cors-proxy-worker/wrangler.toml
@@ -7,4 +7,4 @@ compatibility_date = "2024-01-01"
 #   https://b2j-cors-proxy.<your-account-subdomain>.workers.dev
 #
 # Use that URL as the CORS_PROXY_URL environment variable when building:
-#   CORS_PROXY_URL=https://b2j-cors-proxy.<sub>.workers.dev npm run build
+#   CORS_PROXY_URL=https://<worker-name>.<sub>.workers.dev npm run build

--- a/custom-generator-codelab/package.json
+++ b/custom-generator-codelab/package.json
@@ -20,7 +20,7 @@
     "postbuild": "node scripts/add-build-stamp.js",
     "build:all": "npm run setup && npm run build",
     "deploy": "npm run build:all",
-    "deploy:prod": "CORS_PROXY_URL=https://b2j-cors-proxy.YOUR_SUBDOMAIN.workers.dev npm run build:all"
+    "deploy:prod": "CORS_PROXY_URL=https://YOUR-CORS-PROXY.example.workers.dev npm run build:all"
   },
   "keywords": [
     "blockly"

--- a/custom-generator-codelab/src/utils/GitService.js
+++ b/custom-generator-codelab/src/utils/GitService.js
@@ -25,17 +25,17 @@ export class GitService {
   /**
    * CORS proxy URL.
    * Injected at build time via webpack DefinePlugin from the CORS_PROXY_URL
-   * environment variable.  Defaults to '/cors-proxy' (the local webpack-dev-server
-   * middleware) so development works without any extra configuration.
+   * environment variable.  Defaults to '/cors-proxy' only in local development,
+   * where webpack-dev-server provides that middleware automatically.
    *
-   * For production (e.g. GitHub Pages), set CORS_PROXY_URL to your deployed
-   * Cloudflare Worker URL before running `npm run build`:
+   * For production, set CORS_PROXY_URL to your deployed Cloudflare Worker URL
+   * before running `npm run build`:
    *   CORS_PROXY_URL=https://b2j-cors-proxy.<sub>.workers.dev npm run build
    */
   /* global __CORS_PROXY_URL__ */
-  static CORS_PROXY = (typeof __CORS_PROXY_URL__ !== 'undefined')
+  static CORS_PROXY = typeof __CORS_PROXY_URL__ === 'string'
     ? __CORS_PROXY_URL__
-    : '/cors-proxy';
+    : '';
 
   /** sessionStorage key that holds the full config (URL + credentials) for the active session. */
   static SESSION_KEY = 'b2j_git_config';
@@ -195,6 +195,13 @@ export class GitService {
     return { Authorization: `Basic ${encoded}` };
   }
 
+  static _requireCorsProxy() {
+    if (this.CORS_PROXY) return this.CORS_PROXY;
+    throw new Error(
+      'Git-Zugriff ist nicht konfiguriert: CORS_PROXY_URL fehlt im Production-Build.'
+    );
+  }
+
   // ── Clone ────────────────────────────────────────────────────────────────
 
   /**
@@ -221,7 +228,7 @@ export class GitService {
       http,
       dir: this.REPO_DIR,
       url,
-      corsProxy: this.CORS_PROXY,
+      corsProxy: this._requireCorsProxy(),
       headers: this._authHeaders(finalUsername, finalPassword),
       onAuth: () => ({ username: finalUsername, password: finalPassword }),
       singleBranch: true,
@@ -249,7 +256,7 @@ export class GitService {
       fs,
       http,
       dir: this.REPO_DIR,
-      corsProxy: this.CORS_PROXY,
+      corsProxy: this._requireCorsProxy(),
       headers: this._authHeaders(config.username, config.password),
       onAuth: () => ({ username: config.username, password: config.password }),
       singleBranch: true,
@@ -509,7 +516,7 @@ export class GitService {
       fs,
       http,
       dir: this.REPO_DIR,
-      corsProxy: this.CORS_PROXY,
+      corsProxy: this._requireCorsProxy(),
       headers: this._authHeaders(config.username, config.password),
       onAuth: () => ({ username: config.username, password: config.password }),
     });
@@ -791,7 +798,7 @@ export class GitService {
       await git.fetch({
         fs, http,
         dir: this.REPO_DIR,
-        corsProxy: this.CORS_PROXY,
+        corsProxy: this._requireCorsProxy(),
         headers: this._authHeaders(config.username, config.password),
         onAuth: () => ({ username: config.username, password: config.password }),
         singleBranch: true,

--- a/custom-generator-codelab/webpack.config.js
+++ b/custom-generator-codelab/webpack.config.js
@@ -1,4 +1,4 @@
-const path = require('path');
+const path = require('node:path');
 const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
@@ -10,6 +10,13 @@ const getPublicPath = () => {
     return '/Blockly2Java/';
   }
   return '/';
+};
+
+const getCorsProxyUrl = () => {
+  if (process.env.CORS_PROXY_URL) {
+    return process.env.CORS_PROXY_URL;
+  }
+  return process.env.WEBPACK_SERVE === 'true' ? '/cors-proxy' : '';
 };
 
 // Base config that applies to either development or production mode.
@@ -45,8 +52,8 @@ const config = {
     // can reach servers that don't set Access-Control-Allow-Origin.
     // Requests to /cors-proxy/{host}/{path} are forwarded to https://{host}/{path}.
     setupMiddlewares: (middlewares, _devServer) => {
-      const https = require('https');
-      const nodeHttp = require('http');
+      const https = require('node:https');
+      const nodeHttp = require('node:http');
 
       // Insert at the very front so it runs before any built-in middleware.
       middlewares.unshift({
@@ -149,7 +156,7 @@ const config = {
     // Override at build time: CORS_PROXY_URL=https://... npm run build
     new webpack.DefinePlugin({
       __CORS_PROXY_URL__: JSON.stringify(
-        process.env.CORS_PROXY_URL || '/cors-proxy'
+        getCorsProxyUrl()
       ),
     }),
     // Generate the HTML index page based on our template.
@@ -202,7 +209,7 @@ const config = {
   ],
 };
 
-module.exports = (env, argv) => {
+module.exports = function createWebpackConfig(env, argv) {
   if (argv.mode === 'development') {
     // Set the output path to the `build` directory
     // so we don't clobber production builds.


### PR DESCRIPTION
The changes introduce a CORS proxy URL configuration to resolve 404 errors encountered during cloning operations. This update ensures that the CORS proxy is properly set up for production builds and documented in the deployment instructions.

Fixes #100