### PR TITLE
Fix return-type of prompting blocks

### DIFF
--- a/custom-generator-codelab/src/generators/javascript/javascript_generator.js
+++ b/custom-generator-codelab/src/generators/javascript/javascript_generator.js
@@ -665,6 +665,11 @@ function _resolveAssignedBlockType(workSpace, valueBlock) {
     }
     return 'var';
   }
+  // Prompt/input block returns a String or numeric value depending on its TYPE field.
+  if (valueBlock.type === 'text_prompt_ext' || valueBlock.type === 'text_prompt') {
+    const t = valueBlock.getFieldValue('TYPE');
+    return (t === 'NUMBER') ? TYPES.DOUBLE : TYPES.STRING;
+  }
   return getType(valueBlock.type);
 }
 


### PR DESCRIPTION
Implement type resolution for prompt/input block types to return appropriate String or numeric values based on the TYPE field.