### PR TITLE
Open and close toolbox by hovering instead of clicking

### DIFF
--- a/custom-generator-codelab/src/core/toolbox/toolbox.ts
+++ b/custom-generator-codelab/src/core/toolbox/toolbox.ts
@@ -237,6 +237,14 @@ export class Toolbox
     );
     this.boundEvents_.push(clickEvent);
 
+    const pointerOverEvent = browserEvents.bind(
+      contentsContainer,
+      'mouseover',
+      this,
+      this.onPointerOver_,
+    );
+    this.boundEvents_.push(pointerOverEvent);
+
     const keyDownEvent = browserEvents.conditionalBind(
       contentsContainer,
       'keydown',
@@ -270,6 +278,36 @@ export class Toolbox
       (common.getMainWorkspace() as WorkspaceSvg).hideChaff(true);
     }
     Touch.clearTouchIdentifier();
+  }
+
+  /**
+   * Handles hover events over toolbox items.
+   *
+   * @param e Pointer event to handle.
+   */
+  protected onPointerOver_(e: PointerEvent) {
+    const targetElement = e.target as Element | null;
+    if (!targetElement) {
+      return;
+    }
+
+    const itemId = targetElement.closest('[id]')?.getAttribute('id');
+    if (!itemId) {
+      return;
+    }
+
+    const item = this.getToolboxItemById(itemId);
+    if (!item?.isSelectable()) {
+      return;
+    }
+
+    this.setSelectedItem(item);
+    if (item.isCollapsible()) {
+      const collapsibleItem = item as ICollapsibleToolboxItem;
+      if (!collapsibleItem.isExpanded()) {
+        collapsibleItem.toggleExpanded();
+      }
+    }
   }
 
   /**

--- a/custom-generator-codelab/src/index.js
+++ b/custom-generator-codelab/src/index.js
@@ -227,21 +227,35 @@ function enableToolboxFolderHoverOpen(workspace) {
     return null;
   };
 
+  const isInsideToolboxOrFlyout = (target) => {
+    if (!(target instanceof Element)) return false;
+    return Boolean(target.closest('.blocklyToolboxDiv, .blocklyFlyout'));
+  };
+
   const collapseAllFolders = () => {
-    if (typeof toolbox.getToolboxItems !== 'function') return;
+    if (typeof toolbox.getToolboxItems === 'function') {
+      for (const item of toolbox.getToolboxItems()) {
+        if (!item?.isCollapsible?.()) continue;
+        if (!item.isExpanded?.()) continue;
 
-    for (const item of toolbox.getToolboxItems()) {
-      if (!item?.isCollapsible?.()) continue;
-      if (!item.isExpanded?.()) continue;
-
-      if (typeof item.setExpanded === 'function') {
-        item.setExpanded(false);
-      } else {
-        item.toggleExpanded?.();
+        if (typeof item.setExpanded === 'function') {
+          item.setExpanded(false);
+        } else {
+          item.toggleExpanded?.();
+        }
       }
     }
 
     toolbox.clearSelection?.();
+    const flyout = toolbox.getFlyout?.();
+    flyout?.hide?.();
+    flyout?.setVisible?.(false);
+  };
+
+  const collapseIfOutside = (target) => {
+    if (isInsideToolboxOrFlyout(target)) return;
+    if (workspace.isDragging?.() || workspace.currentGesture_) return;
+    collapseAllFolders();
   };
 
   toolboxDiv.addEventListener('mouseover', (event) => {
@@ -260,9 +274,25 @@ function enableToolboxFolderHoverOpen(workspace) {
     item.toggleExpanded?.();
   });
 
-  toolboxDiv.addEventListener('mouseleave', () => {
-    collapseAllFolders();
+  toolboxDiv.addEventListener('mouseleave', (event) => {
+    collapseIfOutside(event.relatedTarget);
   });
+
+  // Keep folders open while moving from the category list into the flyout,
+  // but collapse once the pointer leaves the flyout and is no longer on the
+  // toolbox list.
+  const flyoutRoot = document.querySelector('.blocklyFlyout');
+  flyoutRoot?.addEventListener('mouseleave', (event) => {
+    collapseIfOutside(event.relatedTarget);
+  });
+
+  document.addEventListener(
+    'mouseover',
+    (event) => {
+      collapseIfOutside(event.target);
+    },
+    true,
+  );
 
   toolboxDiv.dataset.b2jHoverOpenBound = 'true';
 }

--- a/custom-generator-codelab/src/index.js
+++ b/custom-generator-codelab/src/index.js
@@ -178,11 +178,93 @@ function setupBlockly(theme) {
     (btn) => Blockly.Variables.createVariableButtonHandler(btn.getTargetWorkspace(), null, 'local'));
   workspace.registerButtonCallback('CREATE_JAVA_STATIC_ATTR',
     (btn) => Blockly.Variables.createVariableButtonHandler(btn.getTargetWorkspace(), null, 'static'));
+
+  // Open collapsible toolbox folders as soon as the mouse hovers over them.
+  enableToolboxFolderHoverOpen(workspace);
+
   // Toolbox config editor button.
   document.getElementById('toolboxConfigBtn')?.addEventListener('click', () => {
     ToolboxConfigManager.openConfigEditor(ws, FULL_ACTIVE_CONFIG);
   });
   return workspace;
+}
+
+/**
+ * Expands collapsible toolbox folders on mouse hover.
+ *
+ * @param {Blockly.WorkspaceSvg} workspace
+ */
+function enableToolboxFolderHoverOpen(workspace) {
+  const toolbox = workspace.getToolbox?.();
+  if (!toolbox) return;
+
+  const toolboxDiv =
+    toolbox.HtmlDiv ??
+    toolbox.getDiv?.() ??
+    document.querySelector('.blocklyToolboxDiv');
+  if (!toolboxDiv || toolboxDiv.dataset.b2jHoverOpenBound === 'true') return;
+
+  const getHoveredItem = (target) => {
+    if (!(target instanceof Element)) return null;
+
+    const row = target.closest('.blocklyTreeRow');
+    if (!row) return null;
+
+    const itemId = row.getAttribute('id') ?? row.closest('[id]')?.getAttribute('id');
+    if (!itemId) return null;
+
+    if (typeof toolbox.getToolboxItemById === 'function') {
+      return toolbox.getToolboxItemById(itemId);
+    }
+
+    if (typeof toolbox.getToolboxItems === 'function') {
+      return (
+        toolbox.getToolboxItems().find((item) => item.getId?.() === itemId) ??
+        null
+      );
+    }
+
+    return null;
+  };
+
+  const collapseAllFolders = () => {
+    if (typeof toolbox.getToolboxItems !== 'function') return;
+
+    for (const item of toolbox.getToolboxItems()) {
+      if (!item?.isCollapsible?.()) continue;
+      if (!item.isExpanded?.()) continue;
+
+      if (typeof item.setExpanded === 'function') {
+        item.setExpanded(false);
+      } else {
+        item.toggleExpanded?.();
+      }
+    }
+
+    toolbox.clearSelection?.();
+  };
+
+  toolboxDiv.addEventListener('mouseover', (event) => {
+    const item = getHoveredItem(event.target);
+    if (!item?.isSelectable?.()) return;
+
+    toolbox.setSelectedItem?.(item);
+
+    if (!item.isCollapsible?.()) return;
+    if (item.isExpanded?.()) return;
+
+    if (typeof item.setExpanded === 'function') {
+      item.setExpanded(true);
+      return;
+    }
+    item.toggleExpanded?.();
+  });
+
+  toolboxDiv.addEventListener('mouseleave', () => {
+    collapseAllFolders();
+  });
+
+  toolboxDiv.dataset.b2jHoverOpenBound = 'true';
 }
 
 /**


### PR DESCRIPTION
Introduce mouse hover events to expand collapsible toolbox folders and improve the behavior of toolbox item selection.

closes #92