### PR TITLE
'Add 'this' block and update related configurations for Java integration'

### DIFF
--- a/custom-generator-codelab/src/blocks/java_variable_blocks.js
+++ b/custom-generator-codelab/src/blocks/java_variable_blocks.js
@@ -133,7 +133,21 @@ Blockly.Blocks['java_param_get'] = {
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
-// 6. NORMAL ATTRIBUTE – GET  (mirrors variables_get but type-restricted to '')
+// 6. THIS – GET  (variable-like current class instance reference)
+// ─────────────────────────────────────────────────────────────────────────────
+Blockly.Blocks['java_this'] = {
+  init: function () {
+    this.appendDummyInput()
+      .appendField('this');
+    this.setOutput(true, null);
+    this.setStyle('variable_blocks');
+    this.setTooltip('Verweist auf die aktuelle Instanz der geöffneten Klasse.');
+    this.setHelpUrl('');
+  },
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 7. NORMAL ATTRIBUTE – GET  (mirrors variables_get but type-restricted to '')
 // ─────────────────────────────────────────────────────────────────────────────
 Blockly.Blocks['java_normal_attr_get'] = {
   init: function () {
@@ -149,7 +163,7 @@ Blockly.Blocks['java_normal_attr_get'] = {
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
-// 7. NORMAL ATTRIBUTE – SET  (mirrors variables_set but type-restricted to '')
+// 8. NORMAL ATTRIBUTE – SET  (mirrors variables_set but type-restricted to '')
 // ─────────────────────────────────────────────────────────────────────────────
 Blockly.Blocks['java_normal_attr_set'] = {
   init: function () {

--- a/custom-generator-codelab/src/blocks/java_variable_blocks.js
+++ b/custom-generator-codelab/src/blocks/java_variable_blocks.js
@@ -813,9 +813,15 @@ export function allAttrFlyoutCategory(workspace) {
   const attrConfig = ToolboxConfigManager.getSubcategoryConfig('Attribute');
   const show = (name) => attrConfig?.get(name) !== false;
 
+  const instanceBlockFilter = ToolboxConfigManager.getSubcategoryBlockConfig('Attribute', 'Instanz-Attribute');
+  const showInstanceBlock = (type) => !instanceBlockFilter || instanceBlockFilter.get(type) !== false;
+
   const sections = [];
 
   if (show('Instanz-Attribute')) {
+    if (showInstanceBlock('java_this')) {
+      sections.push(makeBlockTemplate('java_this'));
+    }
     sections.push(
       ...normalAttrFlyoutCategory(workspace),
     );

--- a/custom-generator-codelab/src/blocks/java_variable_blocks.js
+++ b/custom-generator-codelab/src/blocks/java_variable_blocks.js
@@ -307,17 +307,12 @@ const METHOD_GROUPS = [
     ],
   },
   {
-    // Pre-filled call-on-object blocks for every method defined in THIS class,
-    // plus blank templates for calls on objects of other classes / library types.
+    // Generic call-on-object templates for methods of other objects/classes.
+    // Keep this section fixed to exactly two blocks (with/without return).
     label: 'Methode eines anderen Objekts aufrufen',
     defs: [],
     calls: [],
-    // objCalls: for each matching def-block, generate an obj-method-call block
-    // pre-filled with method name + args (the OBJ socket stays empty for the user).
-    objCalls: [
-      { defType: 'java_method_noreturn', callType: 'java_obj_method_call_noreturn' },
-      { defType: 'java_method_return',   callType: 'java_obj_method_call_return'   },
-    ],
+    objCalls: [],
     // templates: blank blocks the user can freely configure for any object/method.
     templates: [
       { type: 'java_obj_method_call_noreturn' },
@@ -349,7 +344,21 @@ function makeBlockTemplate(type) {
   const b = Blockly.utils.xml.createElement('block');
   b.setAttribute('type', type);
   b.setAttribute('gap', '16');
+  if (type === 'java_obj_method_call_noreturn' || type === 'java_obj_method_call_return') {
+    _appendThisShadowToObjInput(b);
+  }
   return b;
+}
+
+function _appendThisShadowToObjInput(blockXml) {
+  const value = Blockly.utils.xml.createElement('value');
+  value.setAttribute('name', 'OBJ');
+
+  const shadow = Blockly.utils.xml.createElement('shadow');
+  shadow.setAttribute('type', 'java_this');
+
+  value.appendChild(shadow);
+  blockXml.appendChild(value);
 }
 
 function makeCallBlock(callType, name, argNames) {
@@ -378,6 +387,7 @@ function makeObjCallBlock(callType, name, argNames) {
   const b = Blockly.utils.xml.createElement('block');
   b.setAttribute('type', callType);
   b.setAttribute('gap', '8');
+  _appendThisShadowToObjInput(b);
   // Mutation: shape restoration (arg count + param names).
   const mutation = Blockly.utils.xml.createElement('mutation');
   mutation.setAttribute('args', String(argNames.length));
@@ -521,7 +531,13 @@ export function methodFlyoutCategory(workspace) {
   return xmlList;
 }
 
-function _methodFlyoutCategoryFor(workspace, categoryName, groups, includeStaticParentMethods) {
+function _methodFlyoutCategoryFor(
+  workspace,
+  categoryName,
+  groups,
+  includeStaticParentMethods,
+  includeParentClassMethods = true,
+) {
   const methodConfig = ToolboxConfigManager.getSubcategoryConfig(categoryName);
   const showGroup = (name) => !methodConfig || methodConfig.get(name) !== false;
   const showParamsInline = !ToolboxConfigManager.isCategoryActive('Parameter');
@@ -577,7 +593,9 @@ function _methodFlyoutCategoryFor(workspace, categoryName, groups, includeStatic
     }
   }
 
-  _appendParentClassMethods(workspace, xmlList, includeStaticParentMethods);
+  if (includeParentClassMethods) {
+    _appendParentClassMethods(workspace, xmlList, includeStaticParentMethods);
+  }
 
   return xmlList;
 }
@@ -590,6 +608,7 @@ export function normalMethodFlyoutCategory(workspace) {
       { name: 'Objekt-Methoden', group: METHOD_GROUPS[0] },
       { name: 'Methoden auf Objekten', group: METHOD_GROUPS[2] },
     ],
+    false,
     false,
   );
 }

--- a/custom-generator-codelab/src/generators/javascript/javascript_generator.js
+++ b/custom-generator-codelab/src/generators/javascript/javascript_generator.js
@@ -274,6 +274,8 @@ export function getType(var_type) {
     case 'CLASS':
     case 'callconstructor':
       return TYPES.CLASS;
+    case 'java_this':
+      return getClassName() || TYPES.CLASS;
     // Legacy graphics block names
     case 'graphics_new_world':     return 'World';
     case 'graphics_new_circle':    return 'Circle';

--- a/custom-generator-codelab/src/generators/javascript/variables.js
+++ b/custom-generator-codelab/src/generators/javascript/variables.js
@@ -80,6 +80,10 @@ export function java_param_get(block, generator) {
   const code = getVarCodeName(block.workspace, generator, block.getFieldValue('VAR'));
   return [code, Order.ATOMIC];
 };
+
+export function java_this() {
+  return ['this', Order.ATOMIC];
+};
 // No class-level declaration is generated for local variables.
 // The setter outputs "type name = value;" (inline declaration with inferred type).
 

--- a/custom-generator-codelab/src/toolbox/java.js
+++ b/custom-generator-codelab/src/toolbox/java.js
@@ -37,6 +37,7 @@ export const javaCategories = [
         contents: [
             { kind: 'block', type: 'defconstructor' },
             { kind: 'block', type: 'callconstructor' },
+            { kind: 'block', type: 'java_this' },
             { kind: 'block', type: 'java_extends' },
             { kind: 'block', type: 'java_super_call' },
         ],

--- a/custom-generator-codelab/src/toolbox/java.js
+++ b/custom-generator-codelab/src/toolbox/java.js
@@ -37,7 +37,6 @@ export const javaCategories = [
         contents: [
             { kind: 'block', type: 'defconstructor' },
             { kind: 'block', type: 'callconstructor' },
-            { kind: 'block', type: 'java_this' },
             { kind: 'block', type: 'java_extends' },
             { kind: 'block', type: 'java_super_call' },
         ],

--- a/custom-generator-codelab/src/toolbox_templates/alles.json
+++ b/custom-generator-codelab/src/toolbox_templates/alles.json
@@ -238,6 +238,7 @@
       "blocks": [
         { "type": "defconstructor",  "active": true },
         { "type": "callconstructor", "active": true },
+        { "type": "java_this",       "active": true },
         { "type": "java_extends",    "active": true },
         { "type": "java_super_call", "active": true }
       ]

--- a/custom-generator-codelab/src/toolbox_templates/alles.json
+++ b/custom-generator-codelab/src/toolbox_templates/alles.json
@@ -188,7 +188,13 @@
     {
       "name": "Attribute", "active": true,
       "subcategories": [
-        { "name": "Instanz-Attribute", "active": true },
+        {
+          "name": "Instanz-Attribute",
+          "active": true,
+          "blocks": [
+            { "type": "java_this", "active": true }
+          ]
+        },
         { "name": "Klassen-Attribute", "active": true }
       ]
     },
@@ -238,7 +244,6 @@
       "blocks": [
         { "type": "defconstructor",  "active": true },
         { "type": "callconstructor", "active": true },
-        { "type": "java_this",       "active": true },
         { "type": "java_extends",    "active": true },
         { "type": "java_super_call", "active": true }
       ]

--- a/custom-generator-codelab/src/toolbox_templates/klasse9_mitGrafik.json
+++ b/custom-generator-codelab/src/toolbox_templates/klasse9_mitGrafik.json
@@ -113,7 +113,10 @@
       "subcategories": [
         {
           "name": "Instanz-Attribute",
-          "active": true
+          "active": true,
+          "blocks": [
+            { "type": "java_this", "active": true }
+          ]
         },
         {
           "name": "Klassen-Attribute",
@@ -176,7 +179,6 @@
       "blocks": [
         { "type": "defconstructor", "active": true },
         { "type": "callconstructor", "active": true },
-        { "type": "java_this", "active": true },
         { "type": "java_extends", "active": false },
         { "type": "java_super_call", "active": false }
       ]

--- a/custom-generator-codelab/src/toolbox_templates/klasse9_mitGrafik.json
+++ b/custom-generator-codelab/src/toolbox_templates/klasse9_mitGrafik.json
@@ -176,6 +176,7 @@
       "blocks": [
         { "type": "defconstructor", "active": true },
         { "type": "callconstructor", "active": true },
+        { "type": "java_this", "active": true },
         { "type": "java_extends", "active": false },
         { "type": "java_super_call", "active": false }
       ]

--- a/custom-generator-codelab/src/toolbox_templates/klasse9_mitTurtle.json
+++ b/custom-generator-codelab/src/toolbox_templates/klasse9_mitTurtle.json
@@ -113,7 +113,10 @@
       "subcategories": [
         {
           "name": "Instanz-Attribute",
-          "active": true
+          "active": true,
+          "blocks": [
+            { "type": "java_this", "active": true }
+          ]
         },
         {
           "name": "Klassen-Attribute",
@@ -176,7 +179,6 @@
       "blocks": [
         { "type": "defconstructor", "active": true },
         { "type": "callconstructor", "active": true },
-        { "type": "java_this", "active": true },
         { "type": "java_extends", "active": false },
         { "type": "java_super_call", "active": false }
       ]

--- a/custom-generator-codelab/src/toolbox_templates/klasse9_mitTurtle.json
+++ b/custom-generator-codelab/src/toolbox_templates/klasse9_mitTurtle.json
@@ -176,6 +176,7 @@
       "blocks": [
         { "type": "defconstructor", "active": true },
         { "type": "callconstructor", "active": true },
+        { "type": "java_this", "active": true },
         { "type": "java_extends", "active": false },
         { "type": "java_super_call", "active": false }
       ]

--- a/custom-generator-codelab/src/toolbox_templates/klasse9_ohneGrafik.json
+++ b/custom-generator-codelab/src/toolbox_templates/klasse9_ohneGrafik.json
@@ -103,7 +103,10 @@
       "name": "Attribute", "active": true,
       "subcategories": [
         {
-          "name": "Instanz-Attribute", "active": true
+          "name": "Instanz-Attribute", "active": true,
+          "blocks": [
+            { "type": "java_this", "active": true }
+          ]
         },
         {
           "name": "Klassen-Attribute", "active": false
@@ -157,7 +160,6 @@
       "blocks": [
         { "type": "defconstructor", "active": true },
         { "type": "callconstructor", "active": true },
-        { "type": "java_this", "active": true },
         { "type": "java_extends", "active": false },
         { "type": "java_super_call", "active": false }
       ]

--- a/custom-generator-codelab/src/toolbox_templates/klasse9_ohneGrafik.json
+++ b/custom-generator-codelab/src/toolbox_templates/klasse9_ohneGrafik.json
@@ -157,6 +157,7 @@
       "blocks": [
         { "type": "defconstructor", "active": true },
         { "type": "callconstructor", "active": true },
+        { "type": "java_this", "active": true },
         { "type": "java_extends", "active": false },
         { "type": "java_super_call", "active": false }
       ]

--- a/custom-generator-codelab/src/toolbox_templates/nur_turtle_grafik.json
+++ b/custom-generator-codelab/src/toolbox_templates/nur_turtle_grafik.json
@@ -83,7 +83,7 @@
         { "name": "Klassen-Methoden", "active": true, "blocks": [ { "type": "java_static_method_noreturn", "active": true }, { "type": "java_static_method_return",   "active": true } ] },
         { "name": "Externe Klassen-Methoden", "active": true, "blocks": [ { "type": "java_ext_static_call_noreturn", "active": true }, { "type": "java_ext_static_call_return",   "active": true } ] }
       ] },
-    { "name": "Klassen", "active": true, "blocks": [ { "type": "defconstructor",  "active": true }, { "type": "callconstructor", "active": true }, { "type": "java_extends",    "active": true }, { "type": "java_super_call", "active": true } ] },
+    { "name": "Klassen", "active": true, "blocks": [ { "type": "defconstructor",  "active": true }, { "type": "callconstructor", "active": true }, { "type": "java_this",       "active": true }, { "type": "java_extends",    "active": true }, { "type": "java_super_call", "active": true } ] },
     { "name": "Grafik: Objekte", "active": false, "blocks": [
         { "type": "gfx_extends",        "active": true },
         { "type": "java_local_var_set", "active": true },

--- a/custom-generator-codelab/src/toolbox_templates/nur_turtle_grafik.json
+++ b/custom-generator-codelab/src/toolbox_templates/nur_turtle_grafik.json
@@ -73,7 +73,7 @@
         { "type": "colour_blend",  "active": true }
       ] },
     { "name": "Variablen", "active": true, "subcategories": [ { "name": "Lokale Variablen", "active": true } ] },
-    { "name": "Attribute", "active": true, "subcategories": [ { "name": "Instanz-Attribute", "active": true }, { "name": "Klassen-Attribute", "active": true } ] },
+    { "name": "Attribute", "active": true, "subcategories": [ { "name": "Instanz-Attribute", "active": true, "blocks": [ { "type": "java_this", "active": true } ] }, { "name": "Klassen-Attribute", "active": true } ] },
     { "name": "Parameter", "active": true, "subcategories": [] },
     { "name": "Methoden", "active": true, "subcategories": [
         { "name": "Objekt-Methoden", "active": true, "blocks": [ { "type": "java_method_noreturn", "active": true }, { "type": "java_method_return",   "active": true } ] },
@@ -83,7 +83,7 @@
         { "name": "Klassen-Methoden", "active": true, "blocks": [ { "type": "java_static_method_noreturn", "active": true }, { "type": "java_static_method_return",   "active": true } ] },
         { "name": "Externe Klassen-Methoden", "active": true, "blocks": [ { "type": "java_ext_static_call_noreturn", "active": true }, { "type": "java_ext_static_call_return",   "active": true } ] }
       ] },
-    { "name": "Klassen", "active": true, "blocks": [ { "type": "defconstructor",  "active": true }, { "type": "callconstructor", "active": true }, { "type": "java_this",       "active": true }, { "type": "java_extends",    "active": true }, { "type": "java_super_call", "active": true } ] },
+    { "name": "Klassen", "active": true, "blocks": [ { "type": "defconstructor",  "active": true }, { "type": "callconstructor", "active": true }, { "type": "java_extends",    "active": true }, { "type": "java_super_call", "active": true } ] },
     { "name": "Grafik: Objekte", "active": false, "blocks": [
         { "type": "gfx_extends",        "active": true },
         { "type": "java_local_var_set", "active": true },

--- a/custom-generator-codelab/src/toolbox_templates/ohne_turtle.json
+++ b/custom-generator-codelab/src/toolbox_templates/ohne_turtle.json
@@ -73,7 +73,7 @@
             { "type": "colour_blend",  "active": true }
           ] },
         { "name": "Variablen", "active": true, "subcategories": [ { "name": "Lokale Variablen", "active": true } ] },
-        { "name": "Attribute", "active": true, "subcategories": [ { "name": "Instanz-Attribute", "active": true }, { "name": "Klassen-Attribute", "active": true } ] },
+        { "name": "Attribute", "active": true, "subcategories": [ { "name": "Instanz-Attribute", "active": true, "blocks": [ { "type": "java_this", "active": true } ] }, { "name": "Klassen-Attribute", "active": true } ] },
         { "name": "Parameter", "active": true, "subcategories": [] },
         { "name": "Methoden", "active": true, "subcategories": [
             { "name": "Objekt-Methoden", "active": true, "blocks": [ { "type": "java_method_noreturn", "active": true }, { "type": "java_method_return",   "active": true } ] },
@@ -83,7 +83,7 @@
             { "name": "Klassen-Methoden", "active": true, "blocks": [ { "type": "java_static_method_noreturn", "active": true }, { "type": "java_static_method_return",   "active": true } ] },
             { "name": "Externe Klassen-Methoden", "active": true, "blocks": [ { "type": "java_ext_static_call_noreturn", "active": true }, { "type": "java_ext_static_call_return",   "active": true } ] }
           ] },
-        { "name": "Klassen", "active": true, "blocks": [ { "type": "defconstructor",  "active": true }, { "type": "callconstructor", "active": true }, { "type": "java_this",       "active": true }, { "type": "java_extends",    "active": true }, { "type": "java_super_call", "active": true } ] },
+        { "name": "Klassen", "active": true, "blocks": [ { "type": "defconstructor",  "active": true }, { "type": "callconstructor", "active": true }, { "type": "java_extends",    "active": true }, { "type": "java_super_call", "active": true } ] },
         { "name": "Grafik: Objekte", "active": false, "blocks": [
             { "type": "gfx_extends",        "active": true },
             { "type": "java_local_var_set", "active": true },

--- a/custom-generator-codelab/src/toolbox_templates/ohne_turtle.json
+++ b/custom-generator-codelab/src/toolbox_templates/ohne_turtle.json
@@ -83,7 +83,7 @@
             { "name": "Klassen-Methoden", "active": true, "blocks": [ { "type": "java_static_method_noreturn", "active": true }, { "type": "java_static_method_return",   "active": true } ] },
             { "name": "Externe Klassen-Methoden", "active": true, "blocks": [ { "type": "java_ext_static_call_noreturn", "active": true }, { "type": "java_ext_static_call_return",   "active": true } ] }
           ] },
-        { "name": "Klassen", "active": true, "blocks": [ { "type": "defconstructor",  "active": true }, { "type": "callconstructor", "active": true }, { "type": "java_extends",    "active": true }, { "type": "java_super_call", "active": true } ] },
+        { "name": "Klassen", "active": true, "blocks": [ { "type": "defconstructor",  "active": true }, { "type": "callconstructor", "active": true }, { "type": "java_this",       "active": true }, { "type": "java_extends",    "active": true }, { "type": "java_super_call", "active": true } ] },
         { "name": "Grafik: Objekte", "active": false, "blocks": [
             { "type": "gfx_extends",        "active": true },
             { "type": "java_local_var_set", "active": true },

--- a/custom-generator-codelab/src/utils/ToolboxConfigManager.js
+++ b/custom-generator-codelab/src/utils/ToolboxConfigManager.js
@@ -359,6 +359,7 @@ export class ToolboxConfigManager {
     // Klassen
     defconstructor:           'Konstruktor definieren',
     callconstructor:          'Objekt erzeugen (new)',
+    java_this:                'this (aktuelle Instanz)',
     java_extends:             'Klasse erbt von (extends)',
     java_super_call:          'super(…) aufrufen',
     // Grafik

--- a/custom-generator-codelab/src/utils/WorkspaceManager.js
+++ b/custom-generator-codelab/src/utils/WorkspaceManager.js
@@ -241,7 +241,13 @@ export const FULL_ACTIVE_CONFIG = {
       name: 'Attribute',
       active: true,
       subcategories: [
-        { name: 'Instanz-Attribute', active: true },
+        {
+          name: 'Instanz-Attribute',
+          active: true,
+          blocks: [
+            { type: 'java_this', active: true },
+          ],
+        },
         { name: 'Klassen-Attribute', active: true },
       ],
     },
@@ -299,7 +305,6 @@ export const FULL_ACTIVE_CONFIG = {
       blocks: [
         { type: 'defconstructor',  active: true },
         { type: 'callconstructor', active: true },
-        { type: 'java_this',       active: true },
         { type: 'java_extends',    active: true },
         { type: 'java_super_call', active: true },
       ],

--- a/custom-generator-codelab/src/utils/WorkspaceManager.js
+++ b/custom-generator-codelab/src/utils/WorkspaceManager.js
@@ -299,6 +299,7 @@ export const FULL_ACTIVE_CONFIG = {
       blocks: [
         { type: 'defconstructor',  active: true },
         { type: 'callconstructor', active: true },
+        { type: 'java_this',       active: true },
         { type: 'java_extends',    active: true },
         { type: 'java_super_call', active: true },
       ],


### PR DESCRIPTION
Introduce a new 'this' block to represent the current class instance in Java. Update relevant configurations and templates to include this block, ensuring it integrates seamlessly with existing Java functionality.

closes #128