### PR TITLE
Allow inserting explicit access modifiers in attribute and method names

### DIFF
--- a/custom-generator-codelab/src/generators/javascript/constructors.js
+++ b/custom-generator-codelab/src/generators/javascript/constructors.js
@@ -11,7 +11,7 @@
 // Former goog.module ID: Blockly.JavaScript.procedures
 
 import { javascriptGenerator } from 'blockly/javascript.js';
-import {getType, getVariableType, resolveArgBlockType, parseExplicitType, Order, getClassName, setExtendsClass, TYPES} from './javascript_generator.js';
+import {getType, getVariableType, resolveArgBlockType, parseExplicitSignature, Order, getClassName, setExtendsClass, TYPES} from './javascript_generator.js';
 import * as Blockly from "blockly";
 import LocalStorageManager from '../../utils/LocalStorageManager.js';
 
@@ -80,11 +80,12 @@ export function defconstructor(block, generator) {
     console.log("variables: " + variables);
     for (let i = 0; i < variables.length; i++) {
       // Allow an explicit type prefix in the parameter name (e.g. "int count" → type "int", name "count").
-      const _parsedParam = parseExplicitType(variables[i]);
-      if (_parsedParam) {
+      const _parsedParam = parseExplicitSignature(variables[i]);
+      if (_parsedParam?.type) {
         args[i] = _parsedParam.type + ' ' + _parsedParam.name;
       } else {
-        args[i] = paramTypes[i] + ' ' + variables[i];
+        const paramName = _parsedParam ? _parsedParam.name : variables[i];
+        args[i] = paramTypes[i] + ' ' + paramName;
       }
     }
   }

--- a/custom-generator-codelab/src/generators/javascript/java_methods.js
+++ b/custom-generator-codelab/src/generators/javascript/java_methods.js
@@ -14,7 +14,7 @@
  * the existing getVariableType helper.
  */
 
-import {getType, getVariableType, parseExplicitType, Order, getClassName} from './javascript_generator.js';
+import {getType, getVariableType, parseExplicitSignature, Order, getClassName} from './javascript_generator.js';
 import * as Blockly from 'blockly';
 import LocalStorageManager from '../../utils/LocalStorageManager.js';
 
@@ -46,9 +46,10 @@ function buildMethodCode(block, generator, isStatic) {
   const rawFuncName = block.getFieldValue('NAME') || 'unbekannt';
   // Allow an explicit return type prefix in the method name:
   // e.g. "int myMethod" → return type "int", method name "myMethod".
-  const _parsedFuncName = parseExplicitType(rawFuncName);
+  const _parsedFuncName = parseExplicitSignature(rawFuncName);
   const funcName = _parsedFuncName ? _parsedFuncName.name : rawFuncName;
-  const explicitReturnType = _parsedFuncName ? _parsedFuncName.type : null;
+  const explicitReturnType = _parsedFuncName?.type ?? null;
+  const explicitModifier = _parsedFuncName?.modifier ?? null;
 
   // Reset per-method local-variable tracking so the first use inside every
   // method is always emitted as a declaration, not a plain assignment.
@@ -114,11 +115,12 @@ function buildMethodCode(block, generator, isStatic) {
     for (let i = 0; i < block.arguments_.length; i++) {
       const rawParamName = block.arguments_[i];
       // Allow an explicit type prefix in the parameter name (e.g. "int count" → type "int", identifier "count").
-      const _parsedParam = parseExplicitType(rawParamName);
-      if (_parsedParam) {
+      const _parsedParam = parseExplicitSignature(rawParamName);
+      if (_parsedParam?.type) {
         args.push(_parsedParam.type + ' ' + _parsedParam.name);
         continue;
       }
+      const paramName = _parsedParam ? _parsedParam.name : rawParamName;
       let paramType = varModels[i]
         ? getVariableType(ws, varModels[i].getId(), true)
         : 'Object';
@@ -130,12 +132,13 @@ function buildMethodCode(block, generator, isStatic) {
         const _hint = _crossClassHints[i];
         if (_hint && _hint !== 'var') paramType = _hint;
       }
-      args.push(paramType + ' ' + rawParamName);
+      args.push(paramType + ' ' + paramName);
     }
   }
 
   const staticMod = isStatic ? 'static ' : '';
-  const signature = `public ${staticMod}${returnType} ${funcName}(${args.join(', ')})`;
+  const accessMod = explicitModifier || 'public';
+  const signature = `${accessMod} ${staticMod}${returnType} ${funcName}(${args.join(', ')})`;
   const code = `${signature} {\n${xfix1}${loopTrap}${branch}${xfix2}${returnValue}}`;
   return generator.scrub_(block, code);
 }
@@ -146,7 +149,7 @@ function buildMethodCode(block, generator, isStatic) {
 
 export function java_static_method_noreturn(block, generator) {
   const rawFuncName = block.getFieldValue('NAME') || 'unbekannt';
-  const _p = parseExplicitType(rawFuncName);
+  const _p = parseExplicitSignature(rawFuncName);
   const funcName = _p ? _p.name : rawFuncName;
   const code = buildMethodCode(block, generator, true);
   generator.definitions_['%static_' + funcName] = code;
@@ -156,9 +159,9 @@ export function java_static_method_noreturn(block, generator) {
 
 export function java_static_method_return(block, generator) {
   const rawFuncName = block.getFieldValue('NAME') || 'unbekannt';
-  const _p = parseExplicitType(rawFuncName);
+  const _p = parseExplicitSignature(rawFuncName);
   const funcName = _p ? _p.name : rawFuncName;
-  const returnType = _p ? _p.type : _computeReturnType(block);
+  const returnType = _p?.type ?? _computeReturnType(block);
   const code = buildMethodCode(block, generator, true);
   generator.definitions_['%static_' + funcName] = code;
   LocalStorageManager.storeMethods(getClassName(), { name: funcName, arguments: block.arguments_ || [], isStatic: true, hasReturn: true, returnType });
@@ -167,7 +170,7 @@ export function java_static_method_return(block, generator) {
 
 export function java_method_noreturn(block, generator) {
   const rawFuncName = block.getFieldValue('NAME') || 'unbekannt';
-  const _p = parseExplicitType(rawFuncName);
+  const _p = parseExplicitSignature(rawFuncName);
   const funcName = _p ? _p.name : rawFuncName;
   const code = buildMethodCode(block, generator, false);
   generator.definitions_['%method_' + funcName] = code;
@@ -177,9 +180,9 @@ export function java_method_noreturn(block, generator) {
 
 export function java_method_return(block, generator) {
   const rawFuncName = block.getFieldValue('NAME') || 'unbekannt';
-  const _p = parseExplicitType(rawFuncName);
+  const _p = parseExplicitSignature(rawFuncName);
   const funcName = _p ? _p.name : rawFuncName;
-  const returnType = _p ? _p.type : _computeReturnType(block);
+  const returnType = _p?.type ?? _computeReturnType(block);
   const code = buildMethodCode(block, generator, false);
   generator.definitions_['%method_' + funcName] = code;
   LocalStorageManager.storeMethods(getClassName(), { name: funcName, arguments: block.arguments_ || [], isStatic: false, hasReturn: true, returnType });
@@ -200,7 +203,7 @@ function buildCallArgs(block, generator) {
 
 export function java_static_method_call_noreturn(block, generator) {
   const rawName = block.getFieldValue('NAME');
-  const _p = parseExplicitType(rawName);
+  const _p = parseExplicitSignature(rawName);
   const name = _p ? _p.name : rawName;
   const args = buildCallArgs(block, generator);
   return `${name}(${args});
@@ -209,7 +212,7 @@ export function java_static_method_call_noreturn(block, generator) {
 
 export function java_static_method_call_return(block, generator) {
   const rawName = block.getFieldValue('NAME');
-  const _p = parseExplicitType(rawName);
+  const _p = parseExplicitSignature(rawName);
   const name = _p ? _p.name : rawName;
   const args = buildCallArgs(block, generator);
   return [`${name}(${args})`, Order.ATOMIC];
@@ -217,7 +220,7 @@ export function java_static_method_call_return(block, generator) {
 
 export function java_method_call_noreturn(block, generator) {
   const rawName = block.getFieldValue('NAME');
-  const _p = parseExplicitType(rawName);
+  const _p = parseExplicitSignature(rawName);
   const name = _p ? _p.name : rawName;
   const args = buildCallArgs(block, generator);
   return `${name}(${args});
@@ -226,7 +229,7 @@ export function java_method_call_noreturn(block, generator) {
 
 export function java_method_call_return(block, generator) {
   const rawName = block.getFieldValue('NAME');
-  const _p = parseExplicitType(rawName);
+  const _p = parseExplicitSignature(rawName);
   const name = _p ? _p.name : rawName;
   const args = buildCallArgs(block, generator);
   return [`${name}(${args})`, Order.ATOMIC];

--- a/custom-generator-codelab/src/generators/javascript/javascript_generator.js
+++ b/custom-generator-codelab/src/generators/javascript/javascript_generator.js
@@ -98,6 +98,8 @@ export const TYPES = {
   CLASS: '__CLASS__'
 };
 
+const ACCESS_MODIFIERS = new Set(['public', 'private', 'protected']);
+
 /**
  * Parses an explicit Java type prefix from a Blockly variable or method display name.
  *
@@ -116,6 +118,8 @@ export function parseExplicitType(rawName) {
   const typePart = rawName.slice(0, spaceIdx);
   const namePart = rawName.slice(spaceIdx + 1).trim();
   if (!typePart || !namePart) return null;
+  const firstToken = typePart.trim().split(/\s+/)[0];
+  if (ACCESS_MODIFIERS.has(firstToken)) return null;
   // typePart: Java type identifier, may include package qualifiers (.), generics
   // (<...>, including wildcards like "? extends Foo"), or arrays ([]).
   // For security: avoid complex backtracking regexes. Use a deterministic
@@ -124,6 +128,39 @@ export function parseExplicitType(rawName) {
   // namePart: simple Java identifier (no spaces or special chars)
   if (!/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(namePart)) return null;
   return { type: typePart, name: namePart };
+}
+
+/**
+ * Parses an optional access modifier and/or type prefix from a display name.
+ *
+ * Supported patterns (Java-style):
+ * - "name" → null (no explicit info)
+ * - "type name" → {type, name}
+ * - "modifier name" → {modifier, name}
+ * - "modifier type name" → {modifier, type, name}
+ */
+export function parseExplicitSignature(rawName) {
+  if (!rawName) return null;
+  const trimmed = rawName.trim();
+  if (!trimmed) return null;
+  const firstSpace = trimmed.indexOf(' ');
+  if (firstSpace === -1) return null;
+
+  const firstToken = trimmed.slice(0, firstSpace);
+  if (ACCESS_MODIFIERS.has(firstToken)) {
+    const remainder = trimmed.slice(firstSpace + 1).trim();
+    if (!remainder) return null;
+    const parsed = parseExplicitType(remainder);
+    if (parsed) return { modifier: firstToken, type: parsed.type, name: parsed.name };
+    if (/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(remainder)) {
+      return { modifier: firstToken, type: null, name: remainder };
+    }
+    return null;
+  }
+
+  const parsed = parseExplicitType(trimmed);
+  if (parsed) return { modifier: null, type: parsed.type, name: parsed.name };
+  return null;
 }
 
 /**
@@ -197,7 +234,7 @@ function isValidTypeString(s) {
 export function getVarCodeName(workspace, generator, varId) {
   const varModel = workspace?.getVariableById?.(varId);
   if (varModel) {
-    const parsed = parseExplicitType(varModel.name);
+    const parsed = parseExplicitSignature(varModel.name);
     if (parsed) return parsed.name;
   }
   return generator.getVariableName(varId);
@@ -829,8 +866,8 @@ function _getVariableTypeImpl(workSpace, varId, useCompares, recursionDeepness) 
   // that type unconditionally overrides any automatic inference.
   const _varModel = workSpace.getVariableById?.(varId);
   if (_varModel) {
-    const _explicit = parseExplicitType(_varModel.name);
-    if (_explicit) return _explicit.type;
+    const _explicit = parseExplicitSignature(_varModel.name);
+    if (_explicit?.type) return _explicit.type;
   }
 
   const forLoopType = _searchForLoopVar(workSpace, varId);
@@ -1114,7 +1151,8 @@ export class JavascriptGenerator extends Blockly.CodeGenerator {
         // bare name part as the base for the code identifier (e.g. "int test" → "test"),
         // but still run it through nameDB_ to ensure it is safe and unique.
         const _rawVarName = workspace.getVariableById(varId)?.name ?? '';
-        const _parsedVarName = parseExplicitType(_rawVarName);
+        const _parsedVarName = parseExplicitSignature(_rawVarName);
+        const _explicitModifier = _parsedVarName?.modifier ?? null;
         if (_parsedVarName) {
           name = this.nameDB_.getDistinctName(
             _parsedVarName.name,
@@ -1137,7 +1175,7 @@ export class JavascriptGenerator extends Blockly.CodeGenerator {
           // attribute is still declared in the class body.
           const fallbackType = staticAttrVarIds.has(varId) ? 'static Object' : 'Object';
           if (name.startsWith('static_')) name = name.replace('static_', '');
-          definition.push(fallbackType + ' ' + name);
+          definition.push({ decl: fallbackType + ' ' + name, modifier: _explicitModifier });
         }
         else if(orgType === 'forint')
         {
@@ -1152,7 +1190,7 @@ export class JavascriptGenerator extends Blockly.CodeGenerator {
             if (name.startsWith('static_')) name = name.replace('static_', '');
             type = 'static ' + orgType;
           }
-          definition.push(type + ' ' + name);
+          definition.push({ decl: type + ' ' + name, modifier: _explicitModifier });
         }
         def_map.set(orgType, definition);
       }
@@ -1163,23 +1201,30 @@ export class JavascriptGenerator extends Blockly.CodeGenerator {
     {
       if (value.length > 0) 
       {
-        let uniqueValues = [...new Set(value)];
+        const uniqueValues = [];
+        const seen = new Set();
+        for (const entry of value) {
+          const key = `${entry.modifier || ''}|${entry.decl}`;
+          if (seen.has(key)) continue;
+          seen.add(key);
+          uniqueValues.push(entry);
+        }
         for(let v of uniqueValues)
         {
           //console.log('Variable: ' + v);
           //if(v.includes('var ')){
 
             let comment = '\n'; 
-            let modifier = 'private ';
-            let varName = substringAfterLastSpace(v);
+            let modifier = v.modifier ? v.modifier + ' ' : 'private ';
+            let varName = substringAfterLastSpace(v.decl);
             //console.log('Variable: ' + varName + " | " + v);
             //console.log(variable_definitions);
             if(variable_definitions.includes(" "+varName+";")) {
               comment = "// Attribut doppelt! \n";
               modifier = '//'+modifier;
             }
-            v=v.replace('var ', 'Object ');
-            variable_definitions += modifier + v + "; "+comment;
+            const decl = v.decl.replace('var ', 'Object ');
+            variable_definitions += modifier + decl + "; "+comment;
           // }
           // else {
           //   console.log('Variable ' + v + ' not defined');


### PR DESCRIPTION
Refactor the parameter type parsing logic to utilize `parseExplicitSignature` for constructors and methods, enhancing the handling of explicit type and access modifier parsing. This change improves the clarity and functionality of type definitions in the JavaScript generator.

Closes #74

