### PR TITLE
Add 'java_super' block for superclass reference

### DIFF
--- a/custom-generator-codelab/src/blocks/java_variable_blocks.js
+++ b/custom-generator-codelab/src/blocks/java_variable_blocks.js
@@ -146,6 +146,17 @@ Blockly.Blocks['java_this'] = {
   },
 };
 
+Blockly.Blocks['java_super'] = {
+  init: function () {
+    this.appendDummyInput()
+      .appendField('super');
+    this.setOutput(true, null);
+    this.setStyle('variable_blocks');
+    this.setTooltip('Verweist auf die Oberklasse.');
+    this.setHelpUrl('');
+  },
+};
+
 // ─────────────────────────────────────────────────────────────────────────────
 // 7. NORMAL ATTRIBUTE – GET  (mirrors variables_get but type-restricted to '')
 // ─────────────────────────────────────────────────────────────────────────────
@@ -822,6 +833,9 @@ export function allAttrFlyoutCategory(workspace) {
   // "Instanz-Attribute" section.
   if (showInstanceBlock('java_this')) {
     sections.push(makeBlockTemplate('java_this'));
+  }
+  if (showInstanceBlock('java_super')) {
+    sections.push(makeBlockTemplate('java_super'));
   }
 
   if (show('Instanz-Attribute')) {

--- a/custom-generator-codelab/src/generators/javascript/javascript_generator.js
+++ b/custom-generator-codelab/src/generators/javascript/javascript_generator.js
@@ -313,6 +313,8 @@ export function getType(var_type) {
       return TYPES.CLASS;
     case 'java_this':
       return getClassName() || TYPES.CLASS;
+    case 'java_super':
+      return TYPES.CLASS; // TODO: reicht nur class?
     // Legacy graphics block names
     case 'graphics_new_world':     return 'World';
     case 'graphics_new_circle':    return 'Circle';

--- a/custom-generator-codelab/src/generators/javascript/variables.js
+++ b/custom-generator-codelab/src/generators/javascript/variables.js
@@ -84,6 +84,10 @@ export function java_param_get(block, generator) {
 export function java_this() {
   return ['this', Order.ATOMIC];
 };
+
+export function java_super() {
+  return ['super', Order.ATOMIC];
+};
 // No class-level declaration is generated for local variables.
 // The setter outputs "type name = value;" (inline declaration with inferred type).
 

--- a/custom-generator-codelab/src/toolbox_templates/alles.json
+++ b/custom-generator-codelab/src/toolbox_templates/alles.json
@@ -516,6 +516,10 @@
             {
               "type": "java_this",
               "active": true
+            },
+            {
+              "type": "java_super",
+              "active": true
             }
           ]
         },

--- a/custom-generator-codelab/src/toolbox_templates/klasse9_mitGrafik.json
+++ b/custom-generator-codelab/src/toolbox_templates/klasse9_mitGrafik.json
@@ -288,6 +288,10 @@
             {
               "type": "java_this",
               "active": true
+            },
+            {
+              "type": "java_super",
+              "active": false
             }
           ]
         },

--- a/custom-generator-codelab/src/toolbox_templates/klasse9_mitTurtle.json
+++ b/custom-generator-codelab/src/toolbox_templates/klasse9_mitTurtle.json
@@ -288,6 +288,10 @@
             {
               "type": "java_this",
               "active": true
+            },
+            {
+              "type": "java_super",
+              "active": false
             }
           ]
         },

--- a/custom-generator-codelab/src/toolbox_templates/klasse9_ohneGrafik.json
+++ b/custom-generator-codelab/src/toolbox_templates/klasse9_ohneGrafik.json
@@ -288,6 +288,10 @@
             {
               "type": "java_this",
               "active": true
+            },
+            {
+              "type": "java_super",
+              "active": false
             }
           ]
         },

--- a/custom-generator-codelab/src/toolbox_templates/nur_turtle_grafik.json
+++ b/custom-generator-codelab/src/toolbox_templates/nur_turtle_grafik.json
@@ -288,6 +288,10 @@
             {
               "type": "java_this",
               "active": true
+            },
+            {
+              "type": "java_super",
+              "active": true
             }
           ]
         },

--- a/custom-generator-codelab/src/toolbox_templates/ohne_turtle.json
+++ b/custom-generator-codelab/src/toolbox_templates/ohne_turtle.json
@@ -288,6 +288,10 @@
             {
               "type": "java_this",
               "active": true
+            },
+            {
+              "type": "java_super",
+              "active": true
             }
           ]
         },

--- a/custom-generator-codelab/src/utils/ToolboxConfigManager.js
+++ b/custom-generator-codelab/src/utils/ToolboxConfigManager.js
@@ -360,6 +360,7 @@ export class ToolboxConfigManager {
     defconstructor:           'Konstruktor definieren',
     callconstructor:          'Objekt erzeugen (new)',
     java_this:                'this (aktuelle Instanz)',
+    java_super:                'super (aktuelle Oberklasse)',
     java_extends:             'Klasse erbt von (extends)',
     java_super_call:          'super(…) aufrufen',
     // Grafik

--- a/custom-generator-codelab/src/utils/WorkspaceManager.js
+++ b/custom-generator-codelab/src/utils/WorkspaceManager.js
@@ -230,6 +230,7 @@ export const FULL_ACTIVE_CONFIG = {
           active: true,
           blocks: [
             { type: 'java_this', active: true },
+            { type: 'java_super', active: true },
           ],
         },
         { name: 'Klassen-Attribute', active: true },


### PR DESCRIPTION
Introduce a new block for referencing the superclass in Java, along with necessary generator functions and updates to toolbox templates. This enhances the functionality for users working with class hierarchies.

closes #137