### PR TITLE
Fix Workspace Jumping, Scoped Parameter Scoping & Inference, and Mutator Usability Patches

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,6 +11,9 @@
             "name": "Debug B2J with Chrome",
             "url": "http://localhost:8080",
             "webRoot": "${workspaceFolder}/custom-generator-codelab",
+            "runtimeArgs": [
+                "--incognito"
+            ],
             "preLaunchTask": "npmdev",
             "postDebugTask": "npmstop",
             "sourceMapPathOverrides": {

--- a/custom-generator-codelab/src/blocks/constructor.js
+++ b/custom-generator-codelab/src/blocks/constructor.js
@@ -1,39 +1,7 @@
 import * as Blockly from 'blockly/core';
 import {getClassName} from '../generators/javascript/javascript_generator';
 import LocalStorageManager from '../utils/LocalStorageManager';
-import {getGraphicsSuperArgNames, getGraphicsSuperArgTypes} from './java_graphics_blocks';
-
-// Attach a sensible shadow block to a value input based on its check type.
-function setShadowForInput(block, inputName, checkType) {
-  if (!inputName || !block) return;
-  const inp = block.getInput(inputName);
-  if (!inp || !inp.connection) return;
-  if (!checkType) return; // no shadow for unknown types
-  let shadowType = null;
-  let fieldName = null;
-  let fieldValue = '';
-  switch (checkType) {
-    case 'Number':
-      shadowType = 'math_number'; fieldName = 'NUM'; fieldValue = '0'; break;
-    case 'String':
-      shadowType = 'text'; fieldName = 'TEXT'; fieldValue = '' ; break;
-    case 'Boolean':
-      shadowType = 'logic_boolean'; fieldName = 'BOOL'; fieldValue = 'TRUE'; break;
-    default:
-      return;
-  }
-  try {
-    const shadow = Blockly.utils.xml.createElement('shadow');
-    shadow.setAttribute('type', shadowType);
-    const field = Blockly.utils.xml.createElement('field');
-    field.setAttribute('name', fieldName);
-    field.textContent = fieldValue;
-    shadow.appendChild(field);
-    inp.connection.setShadowDom(shadow);
-  } catch (e) {
-    // Defensive: if Blockly API differs, silently continue.
-  }
-}
+import {getGraphicsSuperArgNames, getGraphicsSuperArgTypes, setShadowForInput} from './java_graphics_blocks';
 
 Blockly.Blocks["defconstructor"] = {
   init: function () {

--- a/custom-generator-codelab/src/blocks/constructor.js
+++ b/custom-generator-codelab/src/blocks/constructor.js
@@ -48,22 +48,35 @@ Blockly.Blocks["defconstructor"] = {
     this.setTooltip('');
     this.setHelpUrl('');
     this.arguments_ = [];
+    this.paramIds_ = []; // Unique variable IDs for each parameter (fixes same-name collision)
     this.setMutator(new Blockly.icons.MutatorIcon(['argument_input'], this));
   },
 
   mutationToDom: function () {
     let container = document.createElement('mutation');
 
-    for (const element of this.arguments_) {
-      const name = element;
+    // Ensure we have a paramId for each argument.
+    while (this.paramIds_.length < this.arguments_.length) {
+      this.paramIds_.push(Blockly.utils.idGenerator.genUid());
+    }
+
+    for (let i = 0; i < this.arguments_.length; i++) {
+      const name = this.arguments_[i];
       const argument = document.createElement('arg');
       argument.setAttribute('name', name);
-
-      if (!this.workspace.getVariable(name, 'param')) {
-        this.workspace.createVariable(name, 'param');
+      // Use the stored unique ID so that parameters with the same name in
+      // different constructors/methods get distinct variable models.
+      let id = this.paramIds_[i];
+      if (!id || !this.workspace.getVariableById(id)) {
+        // Generate a fresh unique ID and create the variable.
+        id = Blockly.utils.idGenerator.genUid();
+        this.paramIds_[i] = id;
       }
-      const id = this.workspace.getVariable(name, 'param').getId();
       argument.setAttribute('varid', id);
+      if (!this.workspace.getVariableById(id)) {
+        // Create a variable with a unique internal ID to avoid collisions.
+        this.workspace.createVariable(name, 'param', id);
+      }
       container.appendChild(argument);
     }
     // NOTE: do NOT call updateShape_() here.
@@ -75,11 +88,17 @@ Blockly.Blocks["defconstructor"] = {
 
   domToMutation: function (xmlElement) {
     this.arguments_ = [];
+    this.paramIds_ = [];
 
     for (let i = 0, childNode; childNode = xmlElement.childNodes[i]; i++) {
       if (childNode.nodeName.toLowerCase() == 'arg') {
         const name = childNode.getAttribute('name');
         this.arguments_.push(name);
+        // Restore the unique variable ID if present.
+        const varid = childNode.getAttribute('varid');
+        if (varid) {
+          this.paramIds_.push(varid);
+        }
       }
     }
     this.updateShape_();
@@ -101,25 +120,35 @@ Blockly.Blocks["defconstructor"] = {
 
   compose: function (containerBlock) {
     const oldArguments = this.arguments_.slice();
+    const oldParamIds = this.paramIds_ ? this.paramIds_.slice() : [];
     let itemBlock = containerBlock.getInputTargetBlock('STACK');
     this.arguments_ = [];
+    this.paramIds_ = [];
     while (itemBlock) {
       const name = itemBlock.getFieldValue('NAME');
       this.arguments_.push(name);
       itemBlock = itemBlock.nextConnection?.targetBlock();
     }
     // Delete workspace variables for params that no longer exist.
-    for (const oldName of oldArguments) {
-      if (!this.arguments_.includes(oldName)) {
-        const oldVar = this.workspace.getVariable(oldName, 'param');
+    for (let i = 0; i < oldArguments.length; i++) {
+      if (!this.arguments_.includes(oldArguments[i])) {
+        const oldVar = this.workspace.getVariableById(oldParamIds[i]);
         if (oldVar) this.workspace.deleteVariableById(oldVar.getId());
       }
     }
-    // Ensure workspace variables exist for every current param.
-    for (const name of this.arguments_) {
-      if (!this.workspace.getVariable(name, 'param')) {
-        this.workspace.createVariable(name, 'param');
+    // Ensure workspace variables exist for every current param with unique IDs.
+    for (let i = 0; i < this.arguments_.length; i++) {
+      const name = this.arguments_[i];
+      const existingId = this.paramIds_[i];
+      if (existingId && this.workspace.getVariableById(existingId)) {
+        // Variable already exists with this ID.
+        continue;
       }
+      // Create a new variable with a unique ID to avoid collisions with
+      // parameters of the same name in other blocks.
+      const uid = Blockly.utils.idGenerator.genUid();
+      this.paramIds_[i] = uid;
+      this.workspace.createVariable(name, 'param', uid);
     }
     this.updateShape_();
   },
@@ -131,8 +160,10 @@ Blockly.Blocks["defconstructor"] = {
     this.setFieldValue(display, 'PARAMS');
   },
   getVarModels: function() {
-    return this.arguments_
-      .map(name => this.workspace.getVariable(name, 'param'))
+    // Use the unique paramIds_ to get the correct variable model for each
+    // parameter, even when multiple parameters share the same name.
+    return (this.paramIds_ || [])
+      .map(id => this.workspace.getVariableById(id))
       .filter(Boolean);
   }
 };

--- a/custom-generator-codelab/src/blocks/java_graphics_blocks.js
+++ b/custom-generator-codelab/src/blocks/java_graphics_blocks.js
@@ -12,6 +12,7 @@
 
 import * as Blockly from 'blockly/core';
 import { VAR_TYPE_LOCAL } from './java_variable_blocks.js';
+import { decomposeCallArg, composeCallArg } from './java_method_blocks.js';
 
 /**
  * Returns an onchange handler that, when a graphics value block is first placed
@@ -494,42 +495,11 @@ Blockly.Blocks['gfx_new_group'] = {
   },
 
   decompose: function (workspace) {
-    const container = workspace.newBlock('call_arg_container');
-    container.initSvg();
-    let connection = container.getInput('STACK').connection;
-    for (let i = 0; i < this.argCount_; i++) {
-      const argBlock = workspace.newBlock('call_arg_input');
-      argBlock.initSvg();
-      connection.connect(argBlock.previousConnection);
-      connection = argBlock.nextConnection;
-    }
-    return container;
+    return decomposeCallArg(this, workspace);
   },
 
   compose: function (containerBlock) {
-    // Save existing connections so attached blocks survive.
-    const savedConns = [];
-    for (let i = 0; i < this.argCount_; i++) {
-      const inp = this.getInput('SHAPE' + i);
-      savedConns[i] = inp?.connection?.targetConnection;
-    }
-
-    // Count new items in mutator container.
-    let newCount = 0;
-    let itemBlock = containerBlock.getInputTargetBlock('STACK');
-    while (itemBlock) {
-      newCount++;
-      itemBlock = itemBlock.nextConnection?.targetBlock();
-    }
-    this.argCount_ = newCount;
-    this._updateShapeInputs();
-
-    // Reconnect surviving blocks.
-    for (let i = 0; i < savedConns.length && i < this.argCount_; i++) {
-      if (savedConns[i]?.getSourceBlock()?.workspace) {
-        this.getInput('SHAPE' + i).connection.connect(savedConns[i]);
-      }
-    }
+    composeCallArg(this, containerBlock, 'SHAPE', '_updateShapeInputs');
   },
 
   _updateShapeInputs: function () {

--- a/custom-generator-codelab/src/blocks/java_graphics_blocks.js
+++ b/custom-generator-codelab/src/blocks/java_graphics_blocks.js
@@ -112,7 +112,7 @@ function buildMethodInputs(block, label, params) {
 }
 
 // Attach a sensible shadow block to a value input based on its check type.
-function setShadowForInput(block, inputName, checkType) {
+export function setShadowForInput(block, inputName, checkType) {
   if (!inputName || !block) return;
   const inp = block.getInput(inputName);
   if (!inp || !inp.connection) return;

--- a/custom-generator-codelab/src/blocks/java_method_blocks.js
+++ b/custom-generator-codelab/src/blocks/java_method_blocks.js
@@ -18,19 +18,58 @@ const STATIC_METHOD_COLOUR = '#AA5555';  // red-ish – static methods
 const NORMAL_METHOD_COLOUR = '#995599';  // purple-ish – instance methods (additional blocks)
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Helper: shared mutation / decompose / compose logic for both method blocks
+// Helper: shared mutation / decompose / compose logic for method blocks.
+//
+// Option A: Parameter metadata (name, unique ID, type) is stored directly on
+// the block instance and in mutation DOM — NO workspace-level 'param' variables
+// are created or looked up.  This avoids Blockly's VariableMap collision bug
+// where two methods with same-named parameters would conflict.
+//
+// Data structures on the block:
+//   paramIds_   : string[] — unique Blockly UIDs per parameter slot
+//   paramTypes_ : string[] — explicit type per parameter slot (e.g. "String")
+//                 populated when the user writes "int count" in the mutator.
 // ─────────────────────────────────────────────────────────────────────────────
 const paramMixin = {
+
+  /**
+   * Parse a parameter name string for an optional explicit type prefix.
+   * E.g. "int count" → { type: 'int', name: 'count' }
+   *      "count"      → { type: null,    name: 'count' }
+   */
+  _parseParamName_: function (name) {
+    // Common Java types to check for.
+    const knownTypes = [
+      'int', 'long', 'float', 'double', 'boolean', 'char', 'byte', 'short',
+      'String', 'Object', 'boolean',
+    ];
+    for (const t of knownTypes) {
+      const regex = new RegExp('^' + t + '\\s+(.+)');
+      const m = name.match(regex);
+      if (m) {
+        return { type: t, name: m[1] };
+      }
+    }
+    return { type: null, name: name };
+  },
+
   mutationToDom: function () {
     const container = document.createElement('mutation');
-    for (const element of this.arguments_) {
-      const name = element;
+    // Ensure we have a paramId and paramType for each argument.
+    while (this.paramIds_.length < this.arguments_.length) {
+      this.paramIds_.push(Blockly.utils.idGenerator.genUid());
+    }
+    while (this.paramTypes_.length < this.arguments_.length) {
+      this.paramTypes_.push('');
+    }
+    for (let i = 0; i < this.arguments_.length; i++) {
       const arg = document.createElement('arg');
-      arg.setAttribute('name', name);
-      if (!this.workspace.getVariable(name, 'param')) {
-        this.workspace.createVariable(name, 'param');
+      arg.setAttribute('name', this.arguments_[i]);
+      arg.setAttribute('varid', this.paramIds_[i]);
+      const parsed = this._parseParamName_(this.arguments_[i]);
+      if (parsed.type) {
+        arg.setAttribute('type', parsed.type);
       }
-      arg.setAttribute('varid', this.workspace.getVariable(name, 'param').getId());
       container.appendChild(arg);
     }
     this.updateShape_();
@@ -39,9 +78,21 @@ const paramMixin = {
 
   domToMutation: function (xmlElement) {
     this.arguments_ = [];
+    this.paramIds_ = [];
+    this.paramTypes_ = [];
     for (let i = 0, child; (child = xmlElement.childNodes[i]); i++) {
       if (child.nodeName.toLowerCase() === 'arg') {
-        this.arguments_.push(child.getAttribute('name'));
+        const rawName = child.getAttribute('name');
+        this.arguments_.push(rawName);
+        const varid = child.getAttribute('varid');
+        if (varid) {
+          this.paramIds_.push(varid);
+        }
+        // Restore explicit type if present in mutation DOM.
+        const t = child.getAttribute('type');
+        if (t) {
+          this.paramTypes_.push(t);
+        }
       }
     }
     this.updateShape_();
@@ -62,27 +113,28 @@ const paramMixin = {
   },
 
   compose: function (containerBlock) {
-    // Snapshot old args before overwriting so we can clean up stale variables.
+    // Snapshot old args and IDs before overwriting so we can track changes.
     const oldArguments = this.arguments_.slice();
+    const oldParamIds = this.paramIds_ ? this.paramIds_.slice() : [];
+    const oldParamTypes = this.paramTypes_ ? this.paramTypes_.slice() : [];
 
     let itemBlock = containerBlock.getInputTargetBlock('STACK');
     this.arguments_ = [];
+    this.paramIds_ = [];
+    this.paramTypes_ = [];
     while (itemBlock) {
-      this.arguments_.push(itemBlock.getFieldValue('NAME'));
+      const rawName = itemBlock.getFieldValue('NAME');
+      this.arguments_.push(rawName);
+      // Generate a fresh unique ID for each parameter slot.
+      this.paramIds_.push(Blockly.utils.idGenerator.genUid());
       itemBlock = itemBlock.nextConnection?.targetBlock();
     }
 
-    // Delete workspace variables for params that no longer exist.
-    for (const oldName of oldArguments) {
-      if (!this.arguments_.includes(oldName)) {
-        const oldVar = this.workspace.getVariable(oldName, 'param');
-        if (oldVar) this.workspace.deleteVariableById(oldVar.getId());
-      }
-    }
-    // Ensure workspace variables exist for every current param.
-    for (const name of this.arguments_) {
-      if (!this.workspace.getVariable(name, 'param')) {
-        this.workspace.createVariable(name, 'param');
+    // Restore explicit types for params that still exist at the same index.
+    for (let i = 0; i < this.arguments_.length; i++) {
+      const idx = oldArguments.indexOf(this.arguments_[i]);
+      if (idx >= 0 && oldParamTypes[idx]) {
+        this.paramTypes_[i] = oldParamTypes[idx];
       }
     }
 
@@ -101,8 +153,37 @@ const paramMixin = {
     this.setFieldValue(display, 'PARAMS');
   },
 
-  getVarModels: function () {
-    return this.arguments_.map(name => this.workspace.getVariable(name, 'param')).filter(Boolean);
+  /**
+   * Returns an array of parameter metadata objects instead of Blockly
+   * variable models.  Each object has: { id, name, type }.
+   *
+   * This replaces getVarModels() which relied on workspace variables.
+   */
+  getParams: function () {
+    const params = [];
+    for (let i = 0; i < this.arguments_.length; i++) {
+      const rawName = this.arguments_[i];
+      const parsed = this._parseParamName_(rawName);
+      params.push({
+        id: this.paramIds_[i] || null,
+        name: parsed.name,
+        // Explicit type from prefix takes priority; fall back to paramTypes_
+        // stored in mutation DOM (for cross-class type hints).
+        type: parsed.type || (this.paramTypes_[i] || ''),
+      });
+    }
+    return params;
+  },
+
+  /**
+   * Set the inferred type for a parameter by slot index.
+   * Used by the generator to store cross-class type hints back on the block.
+   */
+  setParamType: function (index, type) {
+    while (this.paramTypes_.length <= index) {
+      this.paramTypes_.push('');
+    }
+    this.paramTypes_[index] = type;
   },
 };
 
@@ -111,7 +192,6 @@ const paramMixin = {
 // ─────────────────────────────────────────────────────────────────────────────
 Blockly.Blocks['java_static_method_noreturn'] = {
   init: function () {
-    // Inputs are created in their final order — updateShape_ must not move them.
     this.appendDummyInput('TOP_LINE')
       .appendField('Klassen-Methode')
       .appendField(new Blockly.FieldTextInput('methode'), 'NAME')
@@ -123,6 +203,8 @@ Blockly.Blocks['java_static_method_noreturn'] = {
     this.setTooltip('Definiert eine Klassen-Methode ohne Rückgabewert.');
     this.setHelpUrl('');
     this.arguments_ = [];
+    this.paramIds_ = [];
+    this.paramTypes_ = [];
     this.setMutator(new Blockly.icons.MutatorIcon(['argument_input'], this));
     this.setCommentText('');
   },
@@ -148,6 +230,7 @@ Blockly.Blocks['java_static_method_return'] = {
     this.setTooltip('Definiert eine Klassen-Methode mit Rückgabewert.');
     this.setHelpUrl('');
     this.arguments_ = [];
+    this.paramIds_ = []; // Unique variable IDs for each parameter (fixes same-name collision)
     this.setMutator(new Blockly.icons.MutatorIcon(['argument_input'], this));
     this.setCommentText('');
   },
@@ -170,6 +253,7 @@ Blockly.Blocks['java_method_noreturn'] = {
     this.setTooltip('Definiert eine Instanzmethode ohne Rückgabewert.');
     this.setHelpUrl('');
     this.arguments_ = [];
+    this.paramIds_ = []; // Unique variable IDs for each parameter (fixes same-name collision)
     this.setMutator(new Blockly.icons.MutatorIcon(['argument_input'], this));
     this.setCommentText('');
   },
@@ -195,6 +279,7 @@ Blockly.Blocks['java_method_return'] = {
     this.setTooltip('Definiert eine Instanzmethode mit Rückgabewert.');
     this.setHelpUrl('');
     this.arguments_ = [];
+    this.paramIds_ = []; // Unique variable IDs for each parameter (fixes same-name collision)
     this.setMutator(new Blockly.icons.MutatorIcon(['argument_input'], this));
     this.setCommentText('');
   },

--- a/custom-generator-codelab/src/blocks/java_method_blocks.js
+++ b/custom-generator-codelab/src/blocks/java_method_blocks.js
@@ -44,7 +44,7 @@ const paramMixin = {
       'String', 'Object', 'boolean',
     ];
     for (const t of knownTypes) {
-      const regex = new RegExp('^' + t + '\\s+(.+)');
+      const regex = new RegExp(String.raw`^${t}\s+(.+)`);
       const m = name.match(regex);
       if (m) {
         return { type: t, name: m[1] };
@@ -168,7 +168,7 @@ const paramMixin = {
         name: parsed.name,
         // Explicit type from prefix takes priority; fall back to paramTypes_
         // stored in mutation DOM (for cross-class type hints).
-        type: parsed.type || ((this.paramTypes_ && this.paramTypes_[i]) || ''),
+        type: parsed.type || (this.paramTypes_?.[i] || ''),
       });
     }
     return params;

--- a/custom-generator-codelab/src/blocks/java_method_blocks.js
+++ b/custom-generator-codelab/src/blocks/java_method_blocks.js
@@ -277,6 +277,46 @@ Blockly.Blocks['call_arg_input'] = {
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
+export function decomposeCallArg(block, workspace) {
+  const container = workspace.newBlock('call_arg_container');
+  container.initSvg();
+  let connection = container.getInput('STACK').connection;
+  for (let i = 0; i < block.argCount_; i++) {
+    const argBlock = workspace.newBlock('call_arg_input');
+    argBlock.initSvg();
+    connection.connect(argBlock.previousConnection);
+    connection = argBlock.nextConnection;
+  }
+  return container;
+}
+
+export function composeCallArg(block, containerBlock, inputPrefix, rebuildFnName) {
+  // Save existing connections so attached blocks survive.
+  const savedConns = [];
+  for (let i = 0; i < block.argCount_; i++) {
+    const inp = block.getInput(inputPrefix + i);
+    savedConns[i] = inp?.connection?.targetConnection;
+  }
+
+  // Count new items in mutator container.
+  let newCount = 0;
+  let itemBlock = containerBlock.getInputTargetBlock('STACK');
+  while (itemBlock) {
+    newCount++;
+    itemBlock = itemBlock.nextConnection?.targetBlock();
+  }
+  block.argCount_ = newCount;
+  block[rebuildFnName]();
+
+  // Reconnect surviving blocks.
+  for (let i = 0; i < savedConns.length && i < block.argCount_; i++) {
+    if (savedConns[i]?.getSourceBlock()?.workspace) {
+      block.getInput(inputPrefix + i).connection.connect(savedConns[i]);
+    }
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Shared mixin for call blocks (manages ARG0, ARG1, … value inputs)
 // ─────────────────────────────────────────────────────────────────────────────
 const callArgMixin = {
@@ -304,41 +344,11 @@ const callArgMixin = {
   },
 
   decompose: function (workspace) {
-    const container = workspace.newBlock('call_arg_container');
-    container.initSvg();
-    let connection = container.getInput('STACK').connection;
-    for (let i = 0; i < this.argCount_; i++) {
-      const argBlock = workspace.newBlock('call_arg_input');
-      argBlock.initSvg();
-      connection.connect(argBlock.previousConnection);
-      connection = argBlock.nextConnection;
-    }
-    return container;
+    return decomposeCallArg(this, workspace);
   },
 
   compose: function (containerBlock) {
-    // Save existing connections so blocks plugged into ARG inputs survive.
-    const savedConns = [];
-    for (let i = 0; i < this.argCount_; i++) {
-      const inp = this.getInput('ARG' + i);
-      savedConns[i] = inp?.connection?.targetConnection;
-    }
-
-    let newCount = 0;
-    let itemBlock = containerBlock.getInputTargetBlock('STACK');
-    while (itemBlock) {
-      newCount++;
-      itemBlock = itemBlock.nextConnection?.targetBlock()
-    }
-    this.argCount_ = newCount;
-    this.updateArgInputs_();
-
-    // Reconnect surviving blocks.
-    for (let i = 0; i < savedConns.length && i < this.argCount_; i++) {
-      if (savedConns[i]?.getSourceBlock().workspace) {
-        this.getInput('ARG' + i).connection.connect(savedConns[i]);
-      }
-    }
+    composeCallArg(this, containerBlock, 'ARG', 'updateArgInputs_');
   },
 
   updateArgInputs_: function () {

--- a/custom-generator-codelab/src/blocks/java_method_blocks.js
+++ b/custom-generator-codelab/src/blocks/java_method_blocks.js
@@ -55,6 +55,8 @@ const paramMixin = {
 
   mutationToDom: function () {
     const container = document.createElement('mutation');
+    if (!this.paramIds_) this.paramIds_ = [];
+    if (!this.paramTypes_) this.paramTypes_ = [];
     // Ensure we have a paramId and paramType for each argument.
     while (this.paramIds_.length < this.arguments_.length) {
       this.paramIds_.push(Blockly.utils.idGenerator.genUid());
@@ -84,15 +86,12 @@ const paramMixin = {
       if (child.nodeName.toLowerCase() === 'arg') {
         const rawName = child.getAttribute('name');
         this.arguments_.push(rawName);
-        const varid = child.getAttribute('varid');
-        if (varid) {
-          this.paramIds_.push(varid);
-        }
+        // Always ensure a valid unique ID exists for this slot.
+        const varid = child.getAttribute('varid') || Blockly.utils.idGenerator.genUid();
+        this.paramIds_.push(varid);
         // Restore explicit type if present in mutation DOM.
         const t = child.getAttribute('type');
-        if (t) {
-          this.paramTypes_.push(t);
-        }
+        this.paramTypes_.push(t || '');
       }
     }
     this.updateShape_();
@@ -115,27 +114,27 @@ const paramMixin = {
   compose: function (containerBlock) {
     // Snapshot old args and IDs before overwriting so we can track changes.
     const oldArguments = this.arguments_.slice();
-    const oldParamIds = this.paramIds_ ? this.paramIds_.slice() : [];
+    const oldParamIds  = this.paramIds_  ? this.paramIds_.slice()  : [];
     const oldParamTypes = this.paramTypes_ ? this.paramTypes_.slice() : [];
 
     let itemBlock = containerBlock.getInputTargetBlock('STACK');
-    this.arguments_ = [];
-    this.paramIds_ = [];
+    this.arguments_  = [];
+    this.paramIds_   = [];
     this.paramTypes_ = [];
+
     while (itemBlock) {
       const rawName = itemBlock.getFieldValue('NAME');
       this.arguments_.push(rawName);
-      // Generate a fresh unique ID for each parameter slot.
-      this.paramIds_.push(Blockly.utils.idGenerator.genUid());
+      // Reuse the existing ID if this param name survived the edit,
+      // otherwise generate a fresh unique ID.
+      const oldIdx = oldArguments.indexOf(rawName);
+      const reuseId = (oldIdx >= 0 && oldParamIds[oldIdx])
+        ? oldParamIds[oldIdx]
+        : Blockly.utils.idGenerator.genUid();
+      this.paramIds_.push(reuseId);
+      // Restore type annotation if name survived.
+      this.paramTypes_.push(oldIdx >= 0 ? (oldParamTypes[oldIdx] || '') : '');
       itemBlock = itemBlock.nextConnection?.targetBlock();
-    }
-
-    // Restore explicit types for params that still exist at the same index.
-    for (let i = 0; i < this.arguments_.length; i++) {
-      const idx = oldArguments.indexOf(this.arguments_[i]);
-      if (idx >= 0 && oldParamTypes[idx]) {
-        this.paramTypes_[i] = oldParamTypes[idx];
-      }
     }
 
     this.updateShape_();
@@ -165,11 +164,11 @@ const paramMixin = {
       const rawName = this.arguments_[i];
       const parsed = this._parseParamName_(rawName);
       params.push({
-        id: this.paramIds_[i] || null,
+        id: this.paramIds_ ? this.paramIds_[i] : null,
         name: parsed.name,
         // Explicit type from prefix takes priority; fall back to paramTypes_
         // stored in mutation DOM (for cross-class type hints).
-        type: parsed.type || (this.paramTypes_[i] || ''),
+        type: parsed.type || ((this.paramTypes_ && this.paramTypes_[i]) || ''),
       });
     }
     return params;
@@ -180,6 +179,9 @@ const paramMixin = {
    * Used by the generator to store cross-class type hints back on the block.
    */
   setParamType: function (index, type) {
+    if (!this.paramTypes_) {
+      this.paramTypes_ = [];
+    }
     while (this.paramTypes_.length <= index) {
       this.paramTypes_.push('');
     }
@@ -231,6 +233,7 @@ Blockly.Blocks['java_static_method_return'] = {
     this.setHelpUrl('');
     this.arguments_ = [];
     this.paramIds_ = []; // Unique variable IDs for each parameter (fixes same-name collision)
+    this.paramTypes_ = [];
     this.setMutator(new Blockly.icons.MutatorIcon(['argument_input'], this));
     this.setCommentText('');
   },
@@ -254,6 +257,7 @@ Blockly.Blocks['java_method_noreturn'] = {
     this.setHelpUrl('');
     this.arguments_ = [];
     this.paramIds_ = []; // Unique variable IDs for each parameter (fixes same-name collision)
+    this.paramTypes_ = [];
     this.setMutator(new Blockly.icons.MutatorIcon(['argument_input'], this));
     this.setCommentText('');
   },
@@ -280,6 +284,7 @@ Blockly.Blocks['java_method_return'] = {
     this.setHelpUrl('');
     this.arguments_ = [];
     this.paramIds_ = []; // Unique variable IDs for each parameter (fixes same-name collision)
+    this.paramTypes_ = [];
     this.setMutator(new Blockly.icons.MutatorIcon(['argument_input'], this));
     this.setCommentText('');
   },

--- a/custom-generator-codelab/src/blocks/java_method_blocks.js
+++ b/custom-generator-codelab/src/blocks/java_method_blocks.js
@@ -189,26 +189,35 @@ const paramMixin = {
   },
 };
 
+function initMethodBlock(block, label, colour, hasReturn, tooltip) {
+  block.appendDummyInput('TOP_LINE')
+    .appendField(label)
+    .appendField(new Blockly.FieldTextInput('methode'), 'NAME')
+    .appendField(new Blockly.FieldLabel('()'), 'PARAMS');
+  block.appendStatementInput('STACK');
+  if (hasReturn) {
+    block.appendValueInput('RETURN')
+      .setAlign(Blockly.inputs.Align.RIGHT)
+      .appendField('return');
+  }
+  block.setPreviousStatement(false, null);
+  block.setNextStatement(false, null);
+  block.setColour(colour);
+  block.setTooltip(tooltip);
+  block.setHelpUrl('');
+  block.arguments_ = [];
+  block.paramIds_ = [];
+  block.paramTypes_ = [];
+  block.setMutator(new Blockly.icons.MutatorIcon(['argument_input'], block));
+  block.setCommentText('');
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // 1. STATIC METHOD – NO RETURN
 // ─────────────────────────────────────────────────────────────────────────────
 Blockly.Blocks['java_static_method_noreturn'] = {
   init: function () {
-    this.appendDummyInput('TOP_LINE')
-      .appendField('Klassen-Methode')
-      .appendField(new Blockly.FieldTextInput('methode'), 'NAME')
-      .appendField(new Blockly.FieldLabel('()'), 'PARAMS');
-    this.appendStatementInput('STACK');
-    this.setPreviousStatement(false, null);
-    this.setNextStatement(false, null);
-    this.setColour(STATIC_METHOD_COLOUR);
-    this.setTooltip('Definiert eine Klassen-Methode ohne Rückgabewert.');
-    this.setHelpUrl('');
-    this.arguments_ = [];
-    this.paramIds_ = [];
-    this.paramTypes_ = [];
-    this.setMutator(new Blockly.icons.MutatorIcon(['argument_input'], this));
-    this.setCommentText('');
+    initMethodBlock(this, 'Klassen-Methode', STATIC_METHOD_COLOUR, false, 'Definiert eine Klassen-Methode ohne Rückgabewert.');
   },
   ...paramMixin,
 };
@@ -218,24 +227,7 @@ Blockly.Blocks['java_static_method_noreturn'] = {
 // ─────────────────────────────────────────────────────────────────────────────
 Blockly.Blocks['java_static_method_return'] = {
   init: function () {
-    this.appendDummyInput('TOP_LINE')
-      .appendField('Klassen-Methode')
-      .appendField(new Blockly.FieldTextInput('methode'), 'NAME')
-      .appendField(new Blockly.FieldLabel('()'), 'PARAMS');
-    this.appendStatementInput('STACK');
-    this.appendValueInput('RETURN')
-      .setAlign(Blockly.inputs.Align.RIGHT)
-      .appendField('return');
-    this.setPreviousStatement(false, null);
-    this.setNextStatement(false, null);
-    this.setColour(STATIC_METHOD_COLOUR);
-    this.setTooltip('Definiert eine Klassen-Methode mit Rückgabewert.');
-    this.setHelpUrl('');
-    this.arguments_ = [];
-    this.paramIds_ = []; // Unique variable IDs for each parameter (fixes same-name collision)
-    this.paramTypes_ = [];
-    this.setMutator(new Blockly.icons.MutatorIcon(['argument_input'], this));
-    this.setCommentText('');
+    initMethodBlock(this, 'Klassen-Methode', STATIC_METHOD_COLOUR, true, 'Definiert eine Klassen-Methode mit Rückgabewert.');
   },
   ...paramMixin,
 };
@@ -245,21 +237,7 @@ Blockly.Blocks['java_static_method_return'] = {
 // ─────────────────────────────────────────────────────────────────────────────
 Blockly.Blocks['java_method_noreturn'] = {
   init: function () {
-    this.appendDummyInput('TOP_LINE')
-      .appendField('Methode')
-      .appendField(new Blockly.FieldTextInput('methode'), 'NAME')
-      .appendField(new Blockly.FieldLabel('()'), 'PARAMS');
-    this.appendStatementInput('STACK');
-    this.setPreviousStatement(false, null);
-    this.setNextStatement(false, null);
-    this.setColour(NORMAL_METHOD_COLOUR);
-    this.setTooltip('Definiert eine Instanzmethode ohne Rückgabewert.');
-    this.setHelpUrl('');
-    this.arguments_ = [];
-    this.paramIds_ = []; // Unique variable IDs for each parameter (fixes same-name collision)
-    this.paramTypes_ = [];
-    this.setMutator(new Blockly.icons.MutatorIcon(['argument_input'], this));
-    this.setCommentText('');
+    initMethodBlock(this, 'Methode', NORMAL_METHOD_COLOUR, false, 'Definiert eine Instanzmethode ohne Rückgabewert.');
   },
   ...paramMixin,
 };
@@ -269,24 +247,7 @@ Blockly.Blocks['java_method_noreturn'] = {
 // ─────────────────────────────────────────────────────────────────────────────
 Blockly.Blocks['java_method_return'] = {
   init: function () {
-    this.appendDummyInput('TOP_LINE')
-      .appendField('Methode')
-      .appendField(new Blockly.FieldTextInput('methode'), 'NAME')
-      .appendField(new Blockly.FieldLabel('()'), 'PARAMS');
-    this.appendStatementInput('STACK');
-    this.appendValueInput('RETURN')
-      .setAlign(Blockly.inputs.Align.RIGHT)
-      .appendField('return');
-    this.setPreviousStatement(false, null);
-    this.setNextStatement(false, null);
-    this.setColour(NORMAL_METHOD_COLOUR);
-    this.setTooltip('Definiert eine Instanzmethode mit Rückgabewert.');
-    this.setHelpUrl('');
-    this.arguments_ = [];
-    this.paramIds_ = []; // Unique variable IDs for each parameter (fixes same-name collision)
-    this.paramTypes_ = [];
-    this.setMutator(new Blockly.icons.MutatorIcon(['argument_input'], this));
-    this.setCommentText('');
+    initMethodBlock(this, 'Methode', NORMAL_METHOD_COLOUR, true, 'Definiert eine Instanzmethode mit Rückgabewert.');
   },
   ...paramMixin,
 };

--- a/custom-generator-codelab/src/blocks/java_variable_blocks.js
+++ b/custom-generator-codelab/src/blocks/java_variable_blocks.js
@@ -737,6 +737,54 @@ export function staticMethodFlyoutCategory(workspace) {
   );
 }
 
+function fillVariableFlyout(workspace, varType, prefix, setBlockType, getBlockType, btnClass, gap, xmlList) {
+  const variables = workspace.getVariablesOfType(varType);
+  for (let idx = 0; idx < variables.length; idx++) {
+    const variable = variables[idx];
+    const id = variable.getId();
+    _registerManage(workspace, prefix, idx, id);
+
+    // Only show setter/getter blocks for the first variable.
+    if (idx === 0) {
+      const setBlock = Blockly.utils.xml.createElement('block');
+      setBlock.setAttribute('type', setBlockType);
+      setBlock.setAttribute('gap', '8');
+      setBlock.appendChild(varField(variable));
+      xmlList.push(setBlock);
+
+      const getBlock = Blockly.utils.xml.createElement('block');
+      getBlock.setAttribute('type', getBlockType);
+      getBlock.setAttribute('gap', '8');
+      getBlock.appendChild(varField(variable));
+      xmlList.push(getBlock);
+    }
+
+    const manageBtn = Blockly.utils.xml.createElement('button');
+    manageBtn.setAttribute('text', '📝     ' + variable.name);
+    manageBtn.setAttribute('callbackKey', 'MANAGE_' + prefix + '_' + idx);
+    manageBtn.setAttribute('web-class', btnClass);
+    manageBtn.setAttribute('gap', String(gap));
+    xmlList.push(manageBtn);
+  }
+}
+
+function _appendParamBlocks(argNames, paramIds, xmlList) {
+  for (let i = 0; i < argNames.length; i++) {
+    const paramId = paramIds[i];
+    if (!paramId) continue;
+    const getBlock = Blockly.utils.xml.createElement('block');
+    getBlock.setAttribute('type', 'java_param_get');
+    getBlock.setAttribute('gap', i === argNames.length - 1 ? '16' : '4');
+    const field = Blockly.utils.xml.createElement('field');
+    field.setAttribute('name', 'VAR');
+    field.setAttribute('id', paramId);
+    field.setAttribute('variabletype', VAR_TYPE_PARAM);
+    field.appendChild(document.createTextNode(argNames[i]));
+    getBlock.appendChild(field);
+    xmlList.push(getBlock);
+  }
+}
+
 export function normalAttrFlyoutCategory(workspace) {
   const xmlList = [];
 
@@ -746,34 +794,7 @@ export function normalAttrFlyoutCategory(workspace) {
   button.setAttribute('web-class', 'b2j-btn-normal-attr');
   xmlList.push(button);
 
-  const variables = workspace.getVariablesOfType(VAR_TYPE_NORMAL);
-  for (let idx = 0; idx < variables.length; idx++) {
-    const variable = variables[idx];
-    const id = variable.getId();
-    _registerManage(workspace, 'NORMAL', idx, id);
-
-    // Only show setter/getter blocks for the first variable.
-    if (idx === 0) {
-      const setBlock = Blockly.utils.xml.createElement('block');
-      setBlock.setAttribute('type', 'java_normal_attr_set');
-      setBlock.setAttribute('gap', '8');
-      setBlock.appendChild(varField(variable));
-      xmlList.push(setBlock);
-
-      const getBlock = Blockly.utils.xml.createElement('block');
-      getBlock.setAttribute('type', 'java_normal_attr_get');
-      getBlock.setAttribute('gap', '8');
-      getBlock.appendChild(varField(variable));
-      xmlList.push(getBlock);
-    }
-
-    const manageBtn = Blockly.utils.xml.createElement('button');
-    manageBtn.setAttribute('text', '📝     ' + variable.name);
-    manageBtn.setAttribute('callbackKey', 'MANAGE_NORMAL_' + idx);
-    manageBtn.setAttribute('web-class', 'b2j-btn-normal-attr');
-    manageBtn.setAttribute('gap', '0');
-    xmlList.push(manageBtn);
-  }
+  fillVariableFlyout(workspace, VAR_TYPE_NORMAL, 'NORMAL', 'java_normal_attr_set', 'java_normal_attr_get', 'b2j-btn-normal-attr', 0, xmlList);
 
   return xmlList;
 }
@@ -798,20 +819,7 @@ export function paramFlyoutCategory(workspace) {
     const paramIds  = ctrBlock.paramIds_   || [];
     if (argNames.length === 0) continue;
     pushLabel('Konstruktor(' + argNames.join(', ') + ')');
-    for (let i = 0; i < argNames.length; i++) {
-      const paramId = paramIds[i];
-      if (!paramId) continue;
-      const getBlock = Blockly.utils.xml.createElement('block');
-      getBlock.setAttribute('type', 'java_param_get');
-      getBlock.setAttribute('gap', i === argNames.length - 1 ? '16' : '4');
-      const field = Blockly.utils.xml.createElement('field');
-      field.setAttribute('name', 'VAR');
-      field.setAttribute('id', paramId);
-      field.setAttribute('variabletype', VAR_TYPE_PARAM);
-      field.appendChild(document.createTextNode(argNames[i]));
-      getBlock.appendChild(field);
-      xmlList.push(getBlock);
-    }
+    _appendParamBlocks(argNames, paramIds, xmlList);
   }
 
   // ── Method parameters ───────────────────────────────────────────────────
@@ -829,20 +837,7 @@ export function paramFlyoutCategory(workspace) {
       if (argNames.length === 0) continue;
       const methodName = methodBlock.getFieldValue('NAME') || 'unbekannt';
       pushLabel(methodName + '(' + argNames.join(', ') + ')');
-      for (let i = 0; i < argNames.length; i++) {
-        const paramId = paramIds[i];
-        if (!paramId) continue;
-        const getBlock = Blockly.utils.xml.createElement('block');
-        getBlock.setAttribute('type', 'java_param_get');
-        getBlock.setAttribute('gap', i === argNames.length - 1 ? '16' : '4');
-        const field = Blockly.utils.xml.createElement('field');
-        field.setAttribute('name', 'VAR');
-        field.setAttribute('id', paramId);
-        field.setAttribute('variabletype', VAR_TYPE_PARAM);
-        field.appendChild(document.createTextNode(argNames[i]));
-        getBlock.appendChild(field);
-        xmlList.push(getBlock);
-      }
+      _appendParamBlocks(argNames, paramIds, xmlList);
     }
   }
 
@@ -858,34 +853,7 @@ export function localVarFlyoutCategory(workspace) {
   button.setAttribute('web-class', 'b2j-btn-local-var');
   xmlList.push(button);
 
-  const variables = workspace.getVariablesOfType(VAR_TYPE_LOCAL);
-  for (let idx = 0; idx < variables.length; idx++) {
-    const variable = variables[idx];
-    const id = variable.getId();
-    _registerManage(workspace, 'LOCAL', idx, id);
-
-    // Only show setter/getter blocks for the first variable.
-    if (idx === 0) {
-      const setBlock = Blockly.utils.xml.createElement('block');
-      setBlock.setAttribute('type', 'java_local_var_set');
-      setBlock.setAttribute('gap', '8');
-      setBlock.appendChild(varField(variable));
-      xmlList.push(setBlock);
-
-      const getBlock = Blockly.utils.xml.createElement('block');
-      getBlock.setAttribute('type', 'java_local_var_get');
-      getBlock.setAttribute('gap', '8');
-      getBlock.appendChild(varField(variable));
-      xmlList.push(getBlock);
-    }
-
-    const manageBtn = Blockly.utils.xml.createElement('button');
-    manageBtn.setAttribute('text', '📝     ' + variable.name);
-    manageBtn.setAttribute('callbackKey', 'MANAGE_LOCAL_' + idx);
-    manageBtn.setAttribute('web-class', 'b2j-btn-local-var');
-    manageBtn.setAttribute('gap', '4');
-    xmlList.push(manageBtn);
-  }
+  fillVariableFlyout(workspace, VAR_TYPE_LOCAL, 'LOCAL', 'java_local_var_set', 'java_local_var_get', 'b2j-btn-local-var', 4, xmlList);
 
   return xmlList;
 }
@@ -899,34 +867,7 @@ export function staticAttrFlyoutCategory(workspace) {
   button.setAttribute('web-class', 'b2j-btn-static-attr');
   xmlList.push(button);
 
-  const variables = workspace.getVariablesOfType(VAR_TYPE_STATIC);
-  for (let idx = 0; idx < variables.length; idx++) {
-    const variable = variables[idx];
-    const id = variable.getId();
-    _registerManage(workspace, 'STATIC', idx, id);
-
-    // Only show setter/getter blocks for the first variable.
-    if (idx === 0) {
-      const setBlock = Blockly.utils.xml.createElement('block');
-      setBlock.setAttribute('type', 'java_static_attr_set');
-      setBlock.setAttribute('gap', '8');
-      setBlock.appendChild(varField(variable));
-      xmlList.push(setBlock);
-
-      const getBlock = Blockly.utils.xml.createElement('block');
-      getBlock.setAttribute('type', 'java_static_attr_get');
-      getBlock.setAttribute('gap', '8');
-      getBlock.appendChild(varField(variable));
-      xmlList.push(getBlock);
-    }
-
-    const manageBtn = Blockly.utils.xml.createElement('button');
-    manageBtn.setAttribute('text', '📝     ' + variable.name);
-    manageBtn.setAttribute('callbackKey', 'MANAGE_STATIC_' + idx);
-    manageBtn.setAttribute('web-class', 'b2j-btn-static-attr');
-    manageBtn.setAttribute('gap', '4');
-    xmlList.push(manageBtn);
-  }
+  fillVariableFlyout(workspace, VAR_TYPE_STATIC, 'STATIC', 'java_static_attr_set', 'java_static_attr_get', 'b2j-btn-static-attr', 4, xmlList);
 
   return xmlList;
 }

--- a/custom-generator-codelab/src/blocks/java_variable_blocks.js
+++ b/custom-generator-codelab/src/blocks/java_variable_blocks.js
@@ -61,11 +61,19 @@ class ParamFieldVariable extends Blockly.FieldVariable {
     // If the block is not inside a method (e.g. in the flyout), show all.
     if (!parent) return filtered;
 
-    // Keep only variable entries whose ID appears in this method's paramIds_.
-    const allowedIds = new Set(parent.paramIds_ || []);
-    if (allowedIds.size === 0) return filtered;
+    // ── Scope filter: keep only params belonging to this method ──────────
+    // Filter by param *name* (from arguments_), NOT by variable ID (paramIds_).
+    // Rationale: when two methods share a same-named parameter, Blockly's
+    // VariableMap can only hold one workspace variable per (name, type) pair.
+    // The onchange handler redirects the 2nd method's block to reuse the 1st
+    // method's variable ID.  After the redirect, paramIds_[i] no longer matches
+    // the workspace variable ID, so an ID-based filter would hide the entry.
+    // Filtering by name is always correct because VariableMap (name+type)
+    // uniqueness guarantees exactly one entry per param name in the dropdown.
+    const allowedNames = new Set(parent.arguments_ || []);
+    if (allowedNames.size === 0) return filtered;
 
-    const scoped = filtered.filter(([, id]) => allowedIds.has(id));
+    const scoped = filtered.filter(([name,]) => allowedNames.has(name));
 
     // ── Header label: show which method these params belong to ────────────
     // Build a human-readable label like "▸ myMethod(x, y)" and prepend it as

--- a/custom-generator-codelab/src/blocks/java_variable_blocks.js
+++ b/custom-generator-codelab/src/blocks/java_variable_blocks.js
@@ -216,6 +216,7 @@ Blockly.Blocks['java_param_get'] = {
     try {
       this.workspace.createVariable(varName, VAR_TYPE_PARAM, varId);
     } catch (e) {
+      console.warn("Variable creation failed, falling back to existing parameter variable:", e);
       // Blockly's VariableMap throws when a same-name+type variable with a
       // *different* ID already exists.  This can happen if the user loaded
       // a workspace where variable IDs were not unique.  Fall back gracefully:
@@ -737,7 +738,7 @@ export function staticMethodFlyoutCategory(workspace) {
   );
 }
 
-function fillVariableFlyout(workspace, varType, prefix, setBlockType, getBlockType, btnClass, gap, xmlList) {
+function fillVariableFlyout(workspace, varType, prefix, opts, xmlList) {
   const variables = workspace.getVariablesOfType(varType);
   for (let idx = 0; idx < variables.length; idx++) {
     const variable = variables[idx];
@@ -747,13 +748,13 @@ function fillVariableFlyout(workspace, varType, prefix, setBlockType, getBlockTy
     // Only show setter/getter blocks for the first variable.
     if (idx === 0) {
       const setBlock = Blockly.utils.xml.createElement('block');
-      setBlock.setAttribute('type', setBlockType);
+      setBlock.setAttribute('type', opts.setBlockType);
       setBlock.setAttribute('gap', '8');
       setBlock.appendChild(varField(variable));
       xmlList.push(setBlock);
 
       const getBlock = Blockly.utils.xml.createElement('block');
-      getBlock.setAttribute('type', getBlockType);
+      getBlock.setAttribute('type', opts.getBlockType);
       getBlock.setAttribute('gap', '8');
       getBlock.appendChild(varField(variable));
       xmlList.push(getBlock);
@@ -762,8 +763,8 @@ function fillVariableFlyout(workspace, varType, prefix, setBlockType, getBlockTy
     const manageBtn = Blockly.utils.xml.createElement('button');
     manageBtn.setAttribute('text', '📝     ' + variable.name);
     manageBtn.setAttribute('callbackKey', 'MANAGE_' + prefix + '_' + idx);
-    manageBtn.setAttribute('web-class', btnClass);
-    manageBtn.setAttribute('gap', String(gap));
+    manageBtn.setAttribute('web-class', opts.btnClass);
+    manageBtn.setAttribute('gap', String(opts.gap));
     xmlList.push(manageBtn);
   }
 }
@@ -794,7 +795,12 @@ export function normalAttrFlyoutCategory(workspace) {
   button.setAttribute('web-class', 'b2j-btn-normal-attr');
   xmlList.push(button);
 
-  fillVariableFlyout(workspace, VAR_TYPE_NORMAL, 'NORMAL', 'java_normal_attr_set', 'java_normal_attr_get', 'b2j-btn-normal-attr', 0, xmlList);
+  fillVariableFlyout(workspace, VAR_TYPE_NORMAL, 'NORMAL', {
+    setBlockType: 'java_normal_attr_set',
+    getBlockType: 'java_normal_attr_get',
+    btnClass: 'b2j-btn-normal-attr',
+    gap: 0
+  }, xmlList);
 
   return xmlList;
 }
@@ -853,7 +859,12 @@ export function localVarFlyoutCategory(workspace) {
   button.setAttribute('web-class', 'b2j-btn-local-var');
   xmlList.push(button);
 
-  fillVariableFlyout(workspace, VAR_TYPE_LOCAL, 'LOCAL', 'java_local_var_set', 'java_local_var_get', 'b2j-btn-local-var', 4, xmlList);
+  fillVariableFlyout(workspace, VAR_TYPE_LOCAL, 'LOCAL', {
+    setBlockType: 'java_local_var_set',
+    getBlockType: 'java_local_var_get',
+    btnClass: 'b2j-btn-local-var',
+    gap: 4
+  }, xmlList);
 
   return xmlList;
 }
@@ -867,7 +878,12 @@ export function staticAttrFlyoutCategory(workspace) {
   button.setAttribute('web-class', 'b2j-btn-static-attr');
   xmlList.push(button);
 
-  fillVariableFlyout(workspace, VAR_TYPE_STATIC, 'STATIC', 'java_static_attr_set', 'java_static_attr_get', 'b2j-btn-static-attr', 4, xmlList);
+  fillVariableFlyout(workspace, VAR_TYPE_STATIC, 'STATIC', {
+    setBlockType: 'java_static_attr_set',
+    getBlockType: 'java_static_attr_get',
+    btnClass: 'b2j-btn-static-attr',
+    gap: 4
+  }, xmlList);
 
   return xmlList;
 }

--- a/custom-generator-codelab/src/blocks/java_variable_blocks.js
+++ b/custom-generator-codelab/src/blocks/java_variable_blocks.js
@@ -130,6 +130,35 @@ Blockly.Blocks['java_param_get'] = {
     this.setTooltip('Liest einen Methodenparameter. Umbenennen nur über den Methodenkopf möglich.');
     this.setHelpUrl('');
   },
+
+  /**
+   * When this block is placed in the workspace (not inside a flyout),
+   * ensure the workspace variable it references actually exists.
+   * This replaces the need for paramMixin.compose to call createVariable.
+   */
+  onchange: function (event) {
+    // Only act once when the block is first moved to the main workspace.
+    if (this.isInFlyout) return;
+    if (event.type !== Blockly.Events.BLOCK_MOVE && event.type !== Blockly.Events.BLOCK_CREATE) return;
+    if (event.blockId !== this.id) return;
+
+    const varId = this.getFieldValue('VAR');
+    if (!varId) return;
+    if (this.workspace.getVariableById(varId)) return; // already exists
+
+    // Retrieve the name from the field (FieldVariable stores it internally).
+    const field = this.getField('VAR');
+    const varName = field?.getText?.() || 'param';
+
+    // Only create if no same-name param variable already exists to avoid collision.
+    const existing = this.workspace.getVariable(varName, VAR_TYPE_PARAM);
+    if (existing) {
+      // Redirect this field to point at the existing variable.
+      field.setValue(existing.getId());
+    } else {
+      this.workspace.createVariable(varName, VAR_TYPE_PARAM, varId);
+    }
+  },
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -442,17 +471,22 @@ function _appendParentClassMethods(workspace, xmlList, includeStaticMethods = tr
 
 /**
  * Appends inline param-get blocks for argNames when the Parameter category is hidden.
+ * Uses paramIds array to build XML directly from block data instead of workspace variables.
  */
-function _appendInlineParams(workspace, xmlList, argNames) {
+function _appendInlineParams(workspace, xmlList, argNames, paramIds) {
   for (let pi = 0; pi < argNames.length; pi++) {
-    const paramVar = workspace.getVariable(argNames[pi], VAR_TYPE_PARAM);
-    if (paramVar) {
-      const getBlock = Blockly.utils.xml.createElement('block');
-      getBlock.setAttribute('type', 'java_param_get');
-      getBlock.setAttribute('gap', pi === argNames.length - 1 ? '20' : '4');
-      getBlock.appendChild(varField(paramVar));
-      xmlList.push(getBlock);
-    }
+    const paramId = paramIds ? paramIds[pi] : null;
+    if (!paramId) continue;
+    const getBlock = Blockly.utils.xml.createElement('block');
+    getBlock.setAttribute('type', 'java_param_get');
+    getBlock.setAttribute('gap', pi === argNames.length - 1 ? '20' : '4');
+    const field = Blockly.utils.xml.createElement('field');
+    field.setAttribute('name', 'VAR');
+    field.setAttribute('id', paramId);
+    field.setAttribute('variabletype', VAR_TYPE_PARAM);
+    field.appendChild(document.createTextNode(argNames[pi]));
+    getBlock.appendChild(field);
+    xmlList.push(getBlock);
   }
 }
 
@@ -469,9 +503,10 @@ export function methodFlyoutCategory(workspace) {
     const ctrBlocks = workspace.getBlocksByType('defconstructor', true);
     for (const ctrBlock of ctrBlocks) {
       const argNames = ctrBlock.arguments_ || [];
+      const paramIds = ctrBlock.paramIds_ || [];
       if (argNames.length === 0) continue;
       xmlList.push(makeLabel('Konstruktor(' + argNames.join(', ') + ')'));
-      _appendInlineParams(workspace, xmlList, argNames);
+      _appendInlineParams(workspace, xmlList, argNames, paramIds);
     }
   }
 
@@ -511,7 +546,7 @@ export function methodFlyoutCategory(workspace) {
         xmlList.push(callBlock);
 
         // Inline param-get blocks when Parameter category is hidden.
-        if (showParamsInline) _appendInlineParams(workspace, xmlList, argNames);
+        if (showParamsInline) _appendInlineParams(workspace, xmlList, argNames, block.paramIds_);
       }
     }
 
@@ -559,9 +594,10 @@ function _methodFlyoutCategoryFor(
     const ctrBlocks = workspace.getBlocksByType('defconstructor', true);
     for (const ctrBlock of ctrBlocks) {
       const argNames = ctrBlock.arguments_ || [];
+      const paramIds = ctrBlock.paramIds_ || [];
       if (argNames.length === 0) continue;
       xmlList.push(makeLabel('Konstruktor(' + argNames.join(', ') + ')'));
-      _appendInlineParams(workspace, xmlList, argNames);
+      _appendInlineParams(workspace, xmlList, argNames, paramIds);
     }
   }
 
@@ -585,7 +621,7 @@ function _methodFlyoutCategoryFor(
         const callBlock = makeCallBlock(callType, name, argNames);
         callBlock.setAttribute('gap', showParamsInline && argNames.length > 0 ? '4' : '16');
         xmlList.push(callBlock);
-        if (showParamsInline) _appendInlineParams(workspace, xmlList, argNames);
+        if (showParamsInline) _appendInlineParams(workspace, xmlList, argNames, block.paramIds_);
       }
     }
 
@@ -690,24 +726,26 @@ export function paramFlyoutCategory(workspace) {
     xmlList.push(lbl);
   }
 
-  // Helper to push a param-get block for a variable
-  function pushParamBlock(variable, isLast) {
-    const getBlock = Blockly.utils.xml.createElement('block');
-    getBlock.setAttribute('type', 'java_param_get');
-    getBlock.setAttribute('gap', isLast ? '16' : '4');
-    getBlock.appendChild(varField(variable));
-    xmlList.push(getBlock);
-  }
-
   // ── Constructor parameters ──────────────────────────────────────────────
   const ctrBlocks = workspace.getBlocksByType('defconstructor', true);
   for (const ctrBlock of ctrBlocks) {
-    const argNames = ctrBlock.arguments_ || [];
+    const argNames  = ctrBlock.arguments_  || [];
+    const paramIds  = ctrBlock.paramIds_   || [];
     if (argNames.length === 0) continue;
     pushLabel('Konstruktor(' + argNames.join(', ') + ')');
     for (let i = 0; i < argNames.length; i++) {
-      const paramVar = workspace.getVariable(argNames[i], VAR_TYPE_PARAM);
-      if (paramVar) pushParamBlock(paramVar, i === argNames.length - 1);
+      const paramId = paramIds[i];
+      if (!paramId) continue;
+      const getBlock = Blockly.utils.xml.createElement('block');
+      getBlock.setAttribute('type', 'java_param_get');
+      getBlock.setAttribute('gap', i === argNames.length - 1 ? '16' : '4');
+      const field = Blockly.utils.xml.createElement('field');
+      field.setAttribute('name', 'VAR');
+      field.setAttribute('id', paramId);
+      field.setAttribute('variabletype', VAR_TYPE_PARAM);
+      field.appendChild(document.createTextNode(argNames[i]));
+      getBlock.appendChild(field);
+      xmlList.push(getBlock);
     }
   }
 
@@ -721,13 +759,24 @@ export function paramFlyoutCategory(workspace) {
 
   for (const blockType of METHOD_BLOCK_TYPES) {
     for (const methodBlock of workspace.getBlocksByType(blockType, true)) {
-      const argNames = methodBlock.arguments_ || [];
+      const argNames  = methodBlock.arguments_  || [];
+      const paramIds  = methodBlock.paramIds_   || [];
       if (argNames.length === 0) continue;
       const methodName = methodBlock.getFieldValue('NAME') || 'unbekannt';
       pushLabel(methodName + '(' + argNames.join(', ') + ')');
       for (let i = 0; i < argNames.length; i++) {
-        const paramVar = workspace.getVariable(argNames[i], VAR_TYPE_PARAM);
-        if (paramVar) pushParamBlock(paramVar, i === argNames.length - 1);
+        const paramId = paramIds[i];
+        if (!paramId) continue;
+        const getBlock = Blockly.utils.xml.createElement('block');
+        getBlock.setAttribute('type', 'java_param_get');
+        getBlock.setAttribute('gap', i === argNames.length - 1 ? '16' : '4');
+        const field = Blockly.utils.xml.createElement('field');
+        field.setAttribute('name', 'VAR');
+        field.setAttribute('id', paramId);
+        field.setAttribute('variabletype', VAR_TYPE_PARAM);
+        field.appendChild(document.createTextNode(argNames[i]));
+        getBlock.appendChild(field);
+        xmlList.push(getBlock);
       }
     }
   }

--- a/custom-generator-codelab/src/blocks/java_variable_blocks.js
+++ b/custom-generator-codelab/src/blocks/java_variable_blocks.js
@@ -33,16 +33,67 @@ export const STATIC_COLOUR = '#5555AA';   // indigo – static attribute
 // Shows the variable dropdown but omits "Rename" and "Delete" entries so that
 // parameters can only be managed via the method declaration block's mutator.
 // ─────────────────────────────────────────────────────────────────────────────
+// Block types that can own parameters (used for ancestor-walking in getOptions).
+const METHOD_BLOCK_TYPES = new Set([
+  'java_method_noreturn', 'java_method_return',
+  'java_static_method_noreturn', 'java_static_method_return',
+  'defconstructor',
+]);
+
 class ParamFieldVariable extends Blockly.FieldVariable {
   getOptions(opt_useCache) {
     const options = super.getOptions(opt_useCache);
-    // 'RENAME_VARIABLE_ID' / 'DELETE_VARIABLE_ID' are the constant string
-    // values Blockly uses as the second element of the rename/delete menu items.
-    return options.filter(
+    // Remove Rename/Delete entries — params are managed via the method mutator.
+    const filtered = options.filter(
       ([, value]) => value !== 'RENAME_VARIABLE_ID' && value !== 'DELETE_VARIABLE_ID'
     );
+
+    // ── Scope filter: only show params of the enclosing method block ──────
+    const sourceBlock = this.getSourceBlock?.();
+    if (!sourceBlock) return filtered;
+
+    // Walk up the parent chain to find the nearest enclosing method block.
+    let parent = sourceBlock.getParent?.();
+    while (parent) {
+      if (METHOD_BLOCK_TYPES.has(parent.type)) break;
+      parent = parent.getParent?.();
+    }
+    // If the block is not inside a method (e.g. in the flyout), show all.
+    if (!parent) return filtered;
+
+    // Keep only variable entries whose ID appears in this method's paramIds_.
+    const allowedIds = new Set(parent.paramIds_ || []);
+    if (allowedIds.size === 0) return filtered;
+
+    const scoped = filtered.filter(([, id]) => allowedIds.has(id));
+
+    // ── Header label: show which method these params belong to ────────────
+    // Build a human-readable label like "▸ myMethod(x, y)" and prepend it as
+    // a non-selectable header so the user always knows the scope context.
+    const isConstructor = parent.type === 'defconstructor';
+    const rawMethodName = isConstructor
+      ? 'Konstruktor'
+      : (parent.getFieldValue('NAME') || 'Methode');
+    const argNames = parent.arguments_ || [];
+    const headerLabel = '▸ ' + rawMethodName + '(' + argNames.join(', ') + ')';
+
+    // Prepend [displayText, sentinelValue] — the sentinel is filtered out on
+    // selection via doValueUpdate_ below so clicking the header is a no-op.
+    return [['── ' + headerLabel + ' ──', ParamFieldVariable.HEADER_SENTINEL], ...scoped];
+  }
+
+  /**
+   * Intercept value updates: ignore clicks on the header label entry so that
+   * the current variable selection does not change when the user clicks it.
+   */
+  doValueUpdate_(newValue) {
+    if (newValue === ParamFieldVariable.HEADER_SENTINEL) return;
+    super.doValueUpdate_(newValue);
   }
 }
+
+/** Sentinel used as the value of the non-selectable method-name header row. */
+ParamFieldVariable.HEADER_SENTINEL = '__PARAM_GROUP_HEADER__';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // 1. LOCAL VARIABLE – GET  (looks like variables_get, but green)
@@ -144,19 +195,25 @@ Blockly.Blocks['java_param_get'] = {
 
     const varId = this.getFieldValue('VAR');
     if (!varId) return;
-    if (this.workspace.getVariableById(varId)) return; // already exists
+    if (this.workspace.getVariableById(varId)) return; // already exists — nothing to do
 
-    // Retrieve the name from the field (FieldVariable stores it internally).
+    // Retrieve the display name from the field.
     const field = this.getField('VAR');
     const varName = field?.getText?.() || 'param';
 
-    // Only create if no same-name param variable already exists to avoid collision.
-    const existing = this.workspace.getVariable(varName, VAR_TYPE_PARAM);
-    if (existing) {
-      // Redirect this field to point at the existing variable.
-      field.setValue(existing.getId());
-    } else {
+    // Always try to create a workspace variable using the param's own ID
+    // (which is unique per method slot).  This preserves scoping: two methods
+    // with a same-named param will have distinct IDs and therefore distinct
+    // workspace variables, so ParamFieldVariable.getOptions() can filter them.
+    try {
       this.workspace.createVariable(varName, VAR_TYPE_PARAM, varId);
+    } catch (e) {
+      // Blockly's VariableMap throws when a same-name+type variable with a
+      // *different* ID already exists.  This can happen if the user loaded
+      // a workspace where variable IDs were not unique.  Fall back gracefully:
+      // redirect to the existing variable so the block is not left broken.
+      const existing = this.workspace.getVariable(varName, VAR_TYPE_PARAM);
+      if (existing) field.setValue(existing.getId());
     }
   },
 };

--- a/custom-generator-codelab/src/core/icons/mutator_icon.ts
+++ b/custom-generator-codelab/src/core/icons/mutator_icon.ts
@@ -278,15 +278,21 @@ export class MutatorIcon extends Icon implements IHasBubble {
 
   /**
    * Creates a change listener to add to the mini workspace which recomposes
-   * the block.
+   * the block.  Uses a 300 ms debounce delay so that rapid successive events
+   * (e.g. keystrokes in a FieldTextInput) are batched into a single
+   * recomposition.  This prevents the widget dialog from closing mid-edit.
    */
   private createMiniWorkspaceChangeListener() {
     return (e: Abstract) => {
-      if (!MutatorIcon.isIgnorableMutatorEvent(e) && !this.updateWorkspacePid) {
+      if (!MutatorIcon.isIgnorableMutatorEvent(e)) {
+        // Clear any pending recomposition so we restart the debounce timer.
+        if (this.updateWorkspacePid) {
+          clearTimeout(this.updateWorkspacePid);
+        }
         this.updateWorkspacePid = setTimeout(() => {
           this.updateWorkspacePid = null;
           this.recomposeSourceBlock();
-        }, 0);
+        }, 300);
       }
     };
   }
@@ -301,6 +307,7 @@ export class MutatorIcon extends Icon implements IHasBubble {
     return (
       e.isUiEvent ||
       e.type === eventUtils.CREATE ||
+      e.type === eventUtils.BLOCK_FIELD_INTERMEDIATE_CHANGE ||
       (e.type === eventUtils.CHANGE &&
         (e as BlockChange).element === 'disabled')
     );

--- a/custom-generator-codelab/src/core/scrollbar.ts
+++ b/custom-generator-codelab/src/core/scrollbar.ts
@@ -838,35 +838,9 @@ export class Scrollbar {
    */
   private updateMetrics() {
     const ratio = this.getRatio_();
-    // Only update workspace metrics if the ratio has actually changed.
-    // Match the scroll ratio used by resizeContent to avoid jumps after drops.
-    const metrics = this.workspace.getMetrics();
     if (this.horizontal) {
-      const maxScrollDistance = metrics.scrollWidth - metrics.viewWidth;
-      if (maxScrollDistance <= 0) {
-        return;
-      }
-      const currentRatio =
-        (metrics.viewLeft - metrics.scrollLeft) / maxScrollDistance;
-      if (!Number.isFinite(currentRatio)) {
-        return;
-      }
-      if (Math.abs(ratio - currentRatio) > 0.001) {
-        this.workspace.setMetrics({x: ratio});
-      }
-      return;
-    }
-
-    const maxScrollDistance = metrics.scrollHeight - metrics.viewHeight;
-    if (maxScrollDistance <= 0) {
-      return;
-    }
-    const currentRatio =
-      (metrics.viewTop - metrics.scrollTop) / maxScrollDistance;
-    if (!Number.isFinite(currentRatio)) {
-      return;
-    }
-    if (Math.abs(ratio - currentRatio) > 0.001) {
+      this.workspace.setMetrics({x: ratio});
+    } else {
       this.workspace.setMetrics({y: ratio});
     }
   }

--- a/custom-generator-codelab/src/core/scrollbar.ts
+++ b/custom-generator-codelab/src/core/scrollbar.ts
@@ -838,10 +838,20 @@ export class Scrollbar {
    */
   private updateMetrics() {
     const ratio = this.getRatio_();
+    // Only update workspace metrics if the ratio has actually changed
+    // This prevents canvas jumping when scrollbars are resized after block drops
     if (this.horizontal) {
-      this.workspace.setMetrics({x: ratio});
+      const currentRatio = this.workspace.getMetrics().scrollLeft / 
+        (this.workspace.getMetrics().scrollWidth - this.workspace.getMetrics().viewWidth);
+      if (Math.abs(ratio - currentRatio) > 0.001) {
+        this.workspace.setMetrics({x: ratio});
+      }
     } else {
-      this.workspace.setMetrics({y: ratio});
+      const currentRatio = this.workspace.getMetrics().scrollTop / 
+        (this.workspace.getMetrics().scrollHeight - this.workspace.getMetrics().viewHeight);
+      if (Math.abs(ratio - currentRatio) > 0.001) {
+        this.workspace.setMetrics({y: ratio});
+      }
     }
   }
 

--- a/custom-generator-codelab/src/core/scrollbar.ts
+++ b/custom-generator-codelab/src/core/scrollbar.ts
@@ -838,20 +838,36 @@ export class Scrollbar {
    */
   private updateMetrics() {
     const ratio = this.getRatio_();
-    // Only update workspace metrics if the ratio has actually changed
-    // This prevents canvas jumping when scrollbars are resized after block drops
+    // Only update workspace metrics if the ratio has actually changed.
+    // Match the scroll ratio used by resizeContent to avoid jumps after drops.
+    const metrics = this.workspace.getMetrics();
     if (this.horizontal) {
-      const currentRatio = this.workspace.getMetrics().scrollLeft / 
-        (this.workspace.getMetrics().scrollWidth - this.workspace.getMetrics().viewWidth);
+      const maxScrollDistance = metrics.scrollWidth - metrics.viewWidth;
+      if (maxScrollDistance <= 0) {
+        return;
+      }
+      const currentRatio =
+        (metrics.viewLeft - metrics.scrollLeft) / maxScrollDistance;
+      if (!Number.isFinite(currentRatio)) {
+        return;
+      }
       if (Math.abs(ratio - currentRatio) > 0.001) {
         this.workspace.setMetrics({x: ratio});
       }
-    } else {
-      const currentRatio = this.workspace.getMetrics().scrollTop / 
-        (this.workspace.getMetrics().scrollHeight - this.workspace.getMetrics().viewHeight);
-      if (Math.abs(ratio - currentRatio) > 0.001) {
-        this.workspace.setMetrics({y: ratio});
-      }
+      return;
+    }
+
+    const maxScrollDistance = metrics.scrollHeight - metrics.viewHeight;
+    if (maxScrollDistance <= 0) {
+      return;
+    }
+    const currentRatio =
+      (metrics.viewTop - metrics.scrollTop) / maxScrollDistance;
+    if (!Number.isFinite(currentRatio)) {
+      return;
+    }
+    if (Math.abs(ratio - currentRatio) > 0.001) {
+      this.workspace.setMetrics({y: ratio});
     }
   }
 

--- a/custom-generator-codelab/src/core/workspace_svg.ts
+++ b/custom-generator-codelab/src/core/workspace_svg.ts
@@ -33,6 +33,7 @@ import * as eventUtils from './events/utils.js';
 import type {FlyoutButton} from './flyout_button.js';
 import {Gesture} from './gesture.js';
 import {Grid} from './grid.js';
+import {hasBubble} from './interfaces/i_has_bubble.js';
 import type {IASTNodeLocationSvg} from './interfaces/i_ast_node_location_svg.js';
 import type {IBoundedElement} from './interfaces/i_bounded_element.js';
 import type {ICopyData, ICopyable} from './interfaces/i_copyable.js';
@@ -2531,6 +2532,15 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
     Tooltip.hide();
     WidgetDiv.hide();
     dropDownDiv.hideWithoutAnimation();
+
+    const blocks = this.getAllBlocks(false);
+    for (const block of blocks) {
+      for (const icon of block.getIcons()) {
+        if (hasBubble(icon) && icon.bubbleIsVisible()) {
+          icon.setBubbleVisible(false);
+        }
+      }
+    }
 
     this.hideComponents(onlyClosePopups);
   }

--- a/custom-generator-codelab/src/core/workspace_svg.ts
+++ b/custom-generator-codelab/src/core/workspace_svg.ts
@@ -2564,14 +2564,13 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
   ) {
     const metrics = this.getMetrics();
 
-    // Preserve scroll position when xyRatio is 0 (no scroll requested)
-    if (typeof xyRatio.x === 'number' && xyRatio.x !== 0) {
+    if (typeof xyRatio.x === 'number') {
       this.scrollX = -(
         metrics.scrollLeft +
         (metrics.scrollWidth - metrics.viewWidth) * xyRatio.x
       );
     }
-    if (typeof xyRatio.y === 'number' && xyRatio.y !== 0) {
+    if (typeof xyRatio.y === 'number') {
       this.scrollY = -(
         metrics.scrollTop +
         (metrics.scrollHeight - metrics.viewHeight) * xyRatio.y

--- a/custom-generator-codelab/src/core/workspace_svg.ts
+++ b/custom-generator-codelab/src/core/workspace_svg.ts
@@ -2564,18 +2564,20 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
   ) {
     const metrics = this.getMetrics();
 
+    // Preserve scroll position when xyRatio is 0 (no scroll requested)
     if (typeof xyRatio.x === 'number' && xyRatio.x !== 0) {
-        this.scrollX = -(
-          metrics.scrollLeft +
-          (metrics.scrollWidth - metrics.viewWidth) * xyRatio.x
-        );
-      }
+      this.scrollX = -(
+        metrics.scrollLeft +
+        (metrics.scrollWidth - metrics.viewWidth) * xyRatio.x
+      );
+    }
     if (typeof xyRatio.y === 'number' && xyRatio.y !== 0) {
-        this.scrollY = -(
-          metrics.scrollTop +
-          (metrics.scrollHeight - metrics.viewHeight) * xyRatio.y
-        );
-      }
+      this.scrollY = -(
+        metrics.scrollTop +
+        (metrics.scrollHeight - metrics.viewHeight) * xyRatio.y
+      );
+    }
+
     // We have to shift the translation so that when the canvas is at 0, 0 the
     // workspace origin is not underneath the toolbox.
     const x = this.scrollX + metrics.absoluteLeft;

--- a/custom-generator-codelab/src/core/workspace_svg.ts
+++ b/custom-generator-codelab/src/core/workspace_svg.ts
@@ -2564,18 +2564,18 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
   ) {
     const metrics = this.getMetrics();
 
-    if (typeof xyRatio.x === 'number') {
-      this.scrollX = -(
-        metrics.scrollLeft +
-        (metrics.scrollWidth - metrics.viewWidth) * xyRatio.x
-      );
-    }
-    if (typeof xyRatio.y === 'number') {
-      this.scrollY = -(
-        metrics.scrollTop +
-        (metrics.scrollHeight - metrics.viewHeight) * xyRatio.y
-      );
-    }
+    if (typeof xyRatio.x === 'number' && xyRatio.x !== 0) {
+        this.scrollX = -(
+          metrics.scrollLeft +
+          (metrics.scrollWidth - metrics.viewWidth) * xyRatio.x
+        );
+      }
+    if (typeof xyRatio.y === 'number' && xyRatio.y !== 0) {
+        this.scrollY = -(
+          metrics.scrollTop +
+          (metrics.scrollHeight - metrics.viewHeight) * xyRatio.y
+        );
+      }
     // We have to shift the translation so that when the canvas is at 0, 0 the
     // workspace origin is not underneath the toolbox.
     const x = this.scrollX + metrics.absoluteLeft;

--- a/custom-generator-codelab/src/generators/javascript/java_methods.js
+++ b/custom-generator-codelab/src/generators/javascript/java_methods.js
@@ -31,69 +31,55 @@ import LocalStorageManager from '../../utils/LocalStorageManager.js';
 // blocks by their *display name* — no IDs involved, no cross-method leakage.
 // ─────────────────────────────────────────────────────────────────────────────
 
-/**
- * Infers the Java type of a method parameter from how java_param_get blocks
- * with matching display-name are used inside THIS method's body only.
- *
- * @param {Blockly.Block} methodBlock – the method/constructor def block
- * @param {number} paramIndex         – index into methodBlock.arguments_
- * @returns {string} Java type string, or TYPES.UNKNOWN ('var') if undetermined
- */
+const TYPE_AGNOSTIC_PARENTS = new Set([
+  'text_join', 'text_print', 'text_append',
+]);
+
+function isDescendantOf(block, ancestor) {
+  let anc = block.getParent?.();
+  while (anc) {
+    if (anc === ancestor) return true;
+    anc = anc.getParent?.();
+  }
+  return false;
+}
+
+function _checkParamBlock(pb, paramName, ws) {
+  const varId = pb.getFieldValue('VAR');
+  if (!varId) return null;
+  const varModel = ws?.getVariableById(varId);
+  const displayName = varModel?.name ?? pb.getField('VAR')?.getText?.() ?? '';
+  if (displayName !== paramName) return null;
+
+  const parent = pb.getParent();
+  if (!parent || TYPE_AGNOSTIC_PARENTS.has(parent.type)) return null;
+  const t = getType(parent.type);
+  return (t && t !== TYPES.UNKNOWN) ? t : null;
+}
+
 function _inferParamTypeInScope(methodBlock, paramIndex) {
   const paramName = methodBlock.arguments_?.[paramIndex];
   if (!paramName) return TYPES.UNKNOWN;
 
   const ws = methodBlock.workspace;
 
-  // These parent block types accept any Java Object and therefore do NOT
-  // constrain the type of the value plugged into them.
-  const TYPE_AGNOSTIC_PARENTS = new Set([
-    'text_join', 'text_print', 'text_append',
-  ]);
-
-  /**
-   * Given a java_param_get block, checks whether its variable matches paramName
-   * and, if so, returns the Java type inferred from how it is connected.
-   * Returns null when no conclusion can be drawn.
-   */
-  function _checkParamBlock(pb) {
-    // Match by the workspace variable's display name, NOT by ID.
-    // The ID may have been redirected to another method's variable by the
-    // onchange handler, but the display name is always correct.
-    const varId = pb.getFieldValue('VAR');
-    if (!varId) return null;
-    const varModel = ws?.getVariableById(varId);
-    const displayName = varModel?.name ?? pb.getField('VAR')?.getText?.() ?? '';
-    if (displayName !== paramName) return null;
-
-    const parent = pb.getParent();
-    if (!parent || TYPE_AGNOSTIC_PARENTS.has(parent.type)) return null;
-    const t = getType(parent.type);
-    return (t && t !== TYPES.UNKNOWN) ? t : null;
-  }
-
   // ── Strategy 1: fast path via getDescendants ──────────────────────────────
   // Works in all normal cases (method block is a proper container).
   for (const descendant of methodBlock.getDescendants(false)) {
-    if (descendant.type !== 'java_param_get') continue;
-    const t = _checkParamBlock(descendant);
-    if (t) return t;
+    if (descendant.type === 'java_param_get') {
+      const t = _checkParamBlock(descendant, paramName, ws);
+      if (t) return t;
+    }
   }
 
   // ── Strategy 2: workspace scan with explicit ancestor check ───────────────
   // Fallback for edge cases where getDescendants misses connected blocks.
   if (ws) {
     for (const pb of ws.getBlocksByType('java_param_get', false)) {
-      // Walk up the parent chain to verify this block is inside methodBlock.
-      let anc = pb.getParent?.();
-      let inside = false;
-      while (anc) {
-        if (anc === methodBlock) { inside = true; break; }
-        anc = anc.getParent?.();
+      if (isDescendantOf(pb, methodBlock)) {
+        const t = _checkParamBlock(pb, paramName, ws);
+        if (t) return t;
       }
-      if (!inside) continue;
-      const t = _checkParamBlock(pb);
-      if (t) return t;
     }
   }
 
@@ -202,10 +188,8 @@ function buildMethodCode(block, generator, isStatic) {
         continue;
       }
       const paramName = _parsedParam ? _parsedParam.name : rawParamName;
-      // Use the param's own ID from paramIds_ (not getVarModels which is undefined
-      // on paramMixin and always returns []).  getVariableType looks up how the
-      // variable is actually *used* in the body to infer its type.
-      const paramId = block.paramIds_ ? block.paramIds_[i] : null;
+      // getVariableType looks up how the variable is actually *used* in the
+      // body to infer its type.
       let paramType = 'Object';
       // ── Scoped inference: search only this method's body by display name ──
       // Two strategies (getDescendants + ancestor walk) ensure we find the

--- a/custom-generator-codelab/src/generators/javascript/java_methods.js
+++ b/custom-generator-codelab/src/generators/javascript/java_methods.js
@@ -106,7 +106,6 @@ function buildMethodCode(block, generator, isStatic) {
   const ws = Blockly.getMainWorkspace();
   const args = [];
   if (block.arguments_ && block.arguments_.length) {
-    const varModels = block.getVarModels ? block.getVarModels() : [];
     // Retrieve any cross-class call-site type hints stored by other classes
     // that called this method via java_obj_method_call_* / java_ext_static_call_*.
     // Key: "methodName" for instance methods, "ClassName::methodName" for static.
@@ -121,10 +120,15 @@ function buildMethodCode(block, generator, isStatic) {
         continue;
       }
       const paramName = _parsedParam ? _parsedParam.name : rawParamName;
-      let paramType = varModels[i]
-        ? getVariableType(ws, varModels[i].getId(), true)
-        : 'Object';
-      if (paramType === 'var' || !paramType) paramType = 'Object';
+      // Use the param's own ID from paramIds_ (not getVarModels which is undefined
+      // on paramMixin and always returns []).  getVariableType looks up how the
+      // variable is actually *used* in the body to infer its type.
+      const paramId = block.paramIds_ ? block.paramIds_[i] : null;
+      let paramType = 'Object';
+      if (paramId) {
+        const inferred = getVariableType(ws, paramId, true);
+        if (inferred && inferred !== 'var') paramType = inferred;
+      }
       if (paramType === 'forint') paramType = 'int';
       // Fall back to cross-class call-site hints when the workspace-internal
       // inference couldn't determine a concrete type.

--- a/custom-generator-codelab/src/generators/javascript/java_methods.js
+++ b/custom-generator-codelab/src/generators/javascript/java_methods.js
@@ -14,9 +14,91 @@
  * the existing getVariableType helper.
  */
 
-import {getType, getVariableType, parseExplicitSignature, Order, getClassName} from './javascript_generator.js';
+import {getType, getVariableType, parseExplicitSignature, Order, getClassName, TYPES} from './javascript_generator.js';
 import * as Blockly from 'blockly';
 import LocalStorageManager from '../../utils/LocalStorageManager.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scope-aware parameter type inference.
+//
+// Blockly's VariableMap enforces a (name, type) uniqueness constraint.  When
+// two methods share a same-named parameter, the java_param_get onchange handler
+// may redirect one method's block to reuse the other method's variable ID.
+// A workspace-wide, ID-based lookup (getVariableType) then finds usages in the
+// WRONG method and returns a wrong type.
+//
+// Fix: walk only the current method's descendant blocks and match java_param_get
+// blocks by their *display name* — no IDs involved, no cross-method leakage.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Infers the Java type of a method parameter from how java_param_get blocks
+ * with matching display-name are used inside THIS method's body only.
+ *
+ * @param {Blockly.Block} methodBlock – the method/constructor def block
+ * @param {number} paramIndex         – index into methodBlock.arguments_
+ * @returns {string} Java type string, or TYPES.UNKNOWN ('var') if undetermined
+ */
+function _inferParamTypeInScope(methodBlock, paramIndex) {
+  const paramName = methodBlock.arguments_?.[paramIndex];
+  if (!paramName) return TYPES.UNKNOWN;
+
+  const ws = methodBlock.workspace;
+
+  // These parent block types accept any Java Object and therefore do NOT
+  // constrain the type of the value plugged into them.
+  const TYPE_AGNOSTIC_PARENTS = new Set([
+    'text_join', 'text_print', 'text_append',
+  ]);
+
+  /**
+   * Given a java_param_get block, checks whether its variable matches paramName
+   * and, if so, returns the Java type inferred from how it is connected.
+   * Returns null when no conclusion can be drawn.
+   */
+  function _checkParamBlock(pb) {
+    // Match by the workspace variable's display name, NOT by ID.
+    // The ID may have been redirected to another method's variable by the
+    // onchange handler, but the display name is always correct.
+    const varId = pb.getFieldValue('VAR');
+    if (!varId) return null;
+    const varModel = ws?.getVariableById(varId);
+    const displayName = varModel?.name ?? pb.getField('VAR')?.getText?.() ?? '';
+    if (displayName !== paramName) return null;
+
+    const parent = pb.getParent();
+    if (!parent || TYPE_AGNOSTIC_PARENTS.has(parent.type)) return null;
+    const t = getType(parent.type);
+    return (t && t !== TYPES.UNKNOWN) ? t : null;
+  }
+
+  // ── Strategy 1: fast path via getDescendants ──────────────────────────────
+  // Works in all normal cases (method block is a proper container).
+  for (const descendant of methodBlock.getDescendants(false)) {
+    if (descendant.type !== 'java_param_get') continue;
+    const t = _checkParamBlock(descendant);
+    if (t) return t;
+  }
+
+  // ── Strategy 2: workspace scan with explicit ancestor check ───────────────
+  // Fallback for edge cases where getDescendants misses connected blocks.
+  if (ws) {
+    for (const pb of ws.getBlocksByType('java_param_get', false)) {
+      // Walk up the parent chain to verify this block is inside methodBlock.
+      let anc = pb.getParent?.();
+      let inside = false;
+      while (anc) {
+        if (anc === methodBlock) { inside = true; break; }
+        anc = anc.getParent?.();
+      }
+      if (!inside) continue;
+      const t = _checkParamBlock(pb);
+      if (t) return t;
+    }
+  }
+
+  return TYPES.UNKNOWN;
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Shared helper: compute the Java return type of a method block.
@@ -125,10 +207,14 @@ function buildMethodCode(block, generator, isStatic) {
       // variable is actually *used* in the body to infer its type.
       const paramId = block.paramIds_ ? block.paramIds_[i] : null;
       let paramType = 'Object';
-      if (paramId) {
-        const inferred = getVariableType(ws, paramId, true);
-        if (inferred && inferred !== 'var') paramType = inferred;
-      }
+      // ── Scoped inference: search only this method's body by display name ──
+      // Two strategies (getDescendants + ancestor walk) ensure we find the
+      // block even if getDescendants has edge-case gaps.
+      // NO fallback to workspace-wide getVariableType: that would pick up
+      // java_param_get blocks from OTHER methods that share a redirected ID,
+      // producing cross-method type contamination.
+      const scopedType = _inferParamTypeInScope(block, i);
+      paramType = (scopedType && scopedType !== TYPES.UNKNOWN) ? scopedType : 'Object';
       if (paramType === 'forint') paramType = 'int';
       // Fall back to cross-class call-site hints when the workspace-internal
       // inference couldn't determine a concrete type.

--- a/custom-generator-codelab/src/generators/javascript/java_methods.js
+++ b/custom-generator-codelab/src/generators/javascript/java_methods.js
@@ -57,34 +57,37 @@ function _checkParamBlock(pb, paramName, ws) {
   return (t && t !== TYPES.UNKNOWN) ? t : null;
 }
 
-function _inferParamTypeInScope(methodBlock, paramIndex) {
-  const paramName = methodBlock.arguments_?.[paramIndex];
-  if (!paramName) return TYPES.UNKNOWN;
-
-  const ws = methodBlock.workspace;
-
-  // ── Strategy 1: fast path via getDescendants ──────────────────────────────
-  // Works in all normal cases (method block is a proper container).
+function _scanDescendantsForParamType(methodBlock, paramName, ws) {
   for (const descendant of methodBlock.getDescendants(false)) {
     if (descendant.type === 'java_param_get') {
       const t = _checkParamBlock(descendant, paramName, ws);
       if (t) return t;
     }
   }
+  return null;
+}
 
-  // ── Strategy 2: workspace scan with explicit ancestor check ───────────────
-  // Fallback for edge cases where getDescendants misses connected blocks.
-  if (ws) {
-    for (const pb of ws.getBlocksByType('java_param_get', false)) {
-      if (isDescendantOf(pb, methodBlock)) {
-        const t = _checkParamBlock(pb, paramName, ws);
-        if (t) return t;
-      }
+function _scanWorkspaceForParamType(methodBlock, paramName, ws) {
+  if (!ws) return null;
+  for (const pb of ws.getBlocksByType('java_param_get', false)) {
+    if (isDescendantOf(pb, methodBlock)) {
+      const t = _checkParamBlock(pb, paramName, ws);
+      if (t) return t;
     }
   }
-
-  return TYPES.UNKNOWN;
+  return null;
 }
+
+function _inferParamTypeInScope(methodBlock, paramIndex) {
+  const paramName = methodBlock.arguments_?.[paramIndex];
+  if (!paramName) return TYPES.UNKNOWN;
+
+  const ws = methodBlock.workspace;
+  return _scanDescendantsForParamType(methodBlock, paramName, ws)
+    || _scanWorkspaceForParamType(methodBlock, paramName, ws)
+    || TYPES.UNKNOWN;
+}
+
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Shared helper: compute the Java return type of a method block.
@@ -104,6 +107,50 @@ function _computeReturnType(block) {
     }
   }
   return returnType;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared helper: build parameter type declarations.
+// ─────────────────────────────────────────────────────────────────────────────
+function _buildParams(block, funcName, isStatic) {
+  const args = [];
+  if (!block.arguments_ || !block.arguments_.length) {
+    return args;
+  }
+  // Retrieve any cross-class call-site type hints stored by other classes
+  // that called this method via java_obj_method_call_* / java_ext_static_call_*.
+  // Key: "methodName" for instance methods, "ClassName::methodName" for static.
+  const _hintKey = isStatic ? (getClassName() + '::' + funcName) : funcName;
+  const _crossClassHints = LocalStorageManager.getObjCallTypeHints(_hintKey);
+  for (let i = 0; i < block.arguments_.length; i++) {
+    const rawParamName = block.arguments_[i];
+    // Allow an explicit type prefix in the parameter name (e.g. "int count" → type "int", identifier "count").
+    const _parsedParam = parseExplicitSignature(rawParamName);
+    if (_parsedParam?.type) {
+      args.push(_parsedParam.type + ' ' + _parsedParam.name);
+      continue;
+    }
+    const paramName = _parsedParam ? _parsedParam.name : rawParamName;
+    // getVariableType looks up how the variable is actually *used* in the
+    // body to infer its type.
+    // ── Scoped inference: search only this method's body by display name ──
+    // Two strategies (getDescendants + ancestor walk) ensure we find the
+    // block even if getDescendants has edge-case gaps.
+    // NO fallback to workspace-wide getVariableType: that would pick up
+    // java_param_get blocks from OTHER methods that share a redirected ID,
+    // producing cross-method type contamination.
+    const scopedType = _inferParamTypeInScope(block, i);
+    let paramType = (scopedType && scopedType !== TYPES.UNKNOWN) ? scopedType : 'Object';
+    if (paramType === 'forint') paramType = 'int';
+    // Fall back to cross-class call-site hints when the workspace-internal
+    // inference couldn't determine a concrete type.
+    if (paramType === 'Object' && _crossClassHints) {
+      const _hint = _crossClassHints[i];
+      if (_hint && _hint !== 'var') paramType = _hint;
+    }
+    args.push(paramType + ' ' + paramName);
+  }
+  return args;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -150,19 +197,7 @@ function buildMethodCode(block, generator, isStatic) {
   let xfix2 = '';
   if (returnValue) {
     if (branch) xfix2 = xfix1; // revisit block after body
-    const retBlock = block.getInputTargetBlock('RETURN');
-    if (retBlock) {
-      returnType = getType(retBlock.type);
-      if (returnType === 'var') {
-        const id = retBlock.getFieldValue('VAR');
-        if (id) {
-          returnType = getVariableType(Blockly.getMainWorkspace(), id, true);
-          if (returnType === 'var') returnType = 'Object';
-        } else {
-          returnType = 'Object';
-        }
-      }
-    }
+    returnType = _computeReturnType(block);
     returnValue = generator.INDENT + 'return ' + returnValue + ';\n';
   }
 
@@ -171,44 +206,7 @@ function buildMethodCode(block, generator, isStatic) {
   if (explicitReturnType) returnType = explicitReturnType;
 
   // --- parameters ---
-  const ws = Blockly.getMainWorkspace();
-  const args = [];
-  if (block.arguments_ && block.arguments_.length) {
-    // Retrieve any cross-class call-site type hints stored by other classes
-    // that called this method via java_obj_method_call_* / java_ext_static_call_*.
-    // Key: "methodName" for instance methods, "ClassName::methodName" for static.
-    const _hintKey = isStatic ? (getClassName() + '::' + funcName) : funcName;
-    const _crossClassHints = LocalStorageManager.getObjCallTypeHints(_hintKey);
-    for (let i = 0; i < block.arguments_.length; i++) {
-      const rawParamName = block.arguments_[i];
-      // Allow an explicit type prefix in the parameter name (e.g. "int count" → type "int", identifier "count").
-      const _parsedParam = parseExplicitSignature(rawParamName);
-      if (_parsedParam?.type) {
-        args.push(_parsedParam.type + ' ' + _parsedParam.name);
-        continue;
-      }
-      const paramName = _parsedParam ? _parsedParam.name : rawParamName;
-      // getVariableType looks up how the variable is actually *used* in the
-      // body to infer its type.
-      let paramType = 'Object';
-      // ── Scoped inference: search only this method's body by display name ──
-      // Two strategies (getDescendants + ancestor walk) ensure we find the
-      // block even if getDescendants has edge-case gaps.
-      // NO fallback to workspace-wide getVariableType: that would pick up
-      // java_param_get blocks from OTHER methods that share a redirected ID,
-      // producing cross-method type contamination.
-      const scopedType = _inferParamTypeInScope(block, i);
-      paramType = (scopedType && scopedType !== TYPES.UNKNOWN) ? scopedType : 'Object';
-      if (paramType === 'forint') paramType = 'int';
-      // Fall back to cross-class call-site hints when the workspace-internal
-      // inference couldn't determine a concrete type.
-      if (paramType === 'Object' && _crossClassHints) {
-        const _hint = _crossClassHints[i];
-        if (_hint && _hint !== 'var') paramType = _hint;
-      }
-      args.push(paramType + ' ' + paramName);
-    }
-  }
+  const args = _buildParams(block, funcName, isStatic);
 
   const staticMod = isStatic ? 'static ' : '';
   const accessMod = explicitModifier || 'public';
@@ -216,6 +214,7 @@ function buildMethodCode(block, generator, isStatic) {
   const code = `${signature} {\n${xfix1}${loopTrap}${branch}${xfix2}${returnValue}}`;
   return generator.scrub_(block, code);
 }
+
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Block generators

--- a/custom-generator-codelab/src/index.js
+++ b/custom-generator-codelab/src/index.js
@@ -67,14 +67,14 @@ function applyBlocklyPatches() {
   globalThis.document?.addEventListener('mousedown', handlePointerDown, true);
 
   // 2. Patch hideChaff to close mutator and comment bubbles when clicking outside.
-  if (Blockly.WorkspaceSvg && Blockly.WorkspaceSvg.prototype) {
+  if (Blockly.WorkspaceSvg?.prototype) {
     const originalHideChaff = Blockly.WorkspaceSvg.prototype.hideChaff;
     Blockly.WorkspaceSvg.prototype.hideChaff = function (onlyClosePopups) {
       // Call original hideChaff to hide dropdowns and widgetDiv
       originalHideChaff.call(this, onlyClosePopups);
 
       // If the last click was inside a bubble, do not close any bubbles.
-      if (lastPointerDownTarget && lastPointerDownTarget.closest('.blocklyBubbleCanvas')) {
+      if (lastPointerDownTarget?.closest('.blocklyBubbleCanvas')) {
         return;
       }
 
@@ -97,7 +97,7 @@ function applyBlocklyPatches() {
   }
 
   // 3. Patch MutatorIcon to debounce recomposition and ignore intermediate field changes.
-  if (Blockly.icons && Blockly.icons.MutatorIcon) {
+  if (Blockly.icons?.MutatorIcon) {
     const originalIsIgnorable = Blockly.icons.MutatorIcon.isIgnorableMutatorEvent;
     Blockly.icons.MutatorIcon.isIgnorableMutatorEvent = function (e) {
       if (!e) return true;

--- a/custom-generator-codelab/src/index.js
+++ b/custom-generator-codelab/src/index.js
@@ -51,6 +51,78 @@ function hideIdeLoadingOverlay() {
 // Passing onXmlLoaded as callback for REST response
 const restManager = new RestManager(onXmlLoaded, UiManager.showCodeDiv);
 
+/**
+ * Applies runtime patches/fixes to the Blockly core module because the local
+ * changes in `src/core` are not compiled by the project's build system.
+ */
+function applyBlocklyPatches() {
+  // 1. Track the last pointerdown/mousedown target to detect clicks inside bubbles.
+  let lastPointerDownTarget = null;
+
+  const handlePointerDown = (e) => {
+    lastPointerDownTarget = e.target;
+  };
+
+  globalThis.document?.addEventListener('pointerdown', handlePointerDown, true);
+  globalThis.document?.addEventListener('mousedown', handlePointerDown, true);
+
+  // 2. Patch hideChaff to close mutator and comment bubbles when clicking outside.
+  if (Blockly.WorkspaceSvg && Blockly.WorkspaceSvg.prototype) {
+    const originalHideChaff = Blockly.WorkspaceSvg.prototype.hideChaff;
+    Blockly.WorkspaceSvg.prototype.hideChaff = function (onlyClosePopups) {
+      // Call original hideChaff to hide dropdowns and widgetDiv
+      originalHideChaff.call(this, onlyClosePopups);
+
+      // If the last click was inside a bubble, do not close any bubbles.
+      if (lastPointerDownTarget && lastPointerDownTarget.closest('.blocklyBubbleCanvas')) {
+        return;
+      }
+
+      // Close all mutators and comments
+      const blocks = this.getAllBlocks(false);
+      for (const block of blocks) {
+        if (typeof block.getIcons === 'function') {
+          for (const icon of block.getIcons()) {
+            if (
+              typeof icon.bubbleIsVisible === 'function' &&
+              icon.bubbleIsVisible() &&
+              typeof icon.setBubbleVisible === 'function'
+            ) {
+              icon.setBubbleVisible(false);
+            }
+          }
+        }
+      }
+    };
+  }
+
+  // 3. Patch MutatorIcon to debounce recomposition and ignore intermediate field changes.
+  if (Blockly.icons && Blockly.icons.MutatorIcon) {
+    const originalIsIgnorable = Blockly.icons.MutatorIcon.isIgnorableMutatorEvent;
+    Blockly.icons.MutatorIcon.isIgnorableMutatorEvent = function (e) {
+      if (!e) return true;
+      return (
+        originalIsIgnorable.call(this, e) ||
+        e.type === 'block_field_intermediate_change' ||
+        (Blockly.Events && e.type === Blockly.Events.BLOCK_FIELD_INTERMEDIATE_CHANGE)
+      );
+    };
+
+    Blockly.icons.MutatorIcon.prototype.createMiniWorkspaceChangeListener = function () {
+      return (e) => {
+        if (!Blockly.icons.MutatorIcon.isIgnorableMutatorEvent(e)) {
+          if (this.updateWorkspacePid) {
+            clearTimeout(this.updateWorkspacePid);
+          }
+          this.updateWorkspacePid = setTimeout(() => {
+            this.updateWorkspacePid = null;
+            this.recomposeSourceBlock();
+          }, 300);
+        }
+      };
+    };
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Step 1 – Initialization  (page opens)
@@ -62,6 +134,7 @@ const restManager = new RestManager(onXmlLoaded, UiManager.showCodeDiv);
  * initial load, first code generation, and listener registration.
  */
 function init() {
+  applyBlocklyPatches();
   const theme = UiManager.setupTheme();
   ws = setupBlockly(theme);
   UiManager.setupLayout(ws);

--- a/custom-generator-codelab/src/index.js
+++ b/custom-generator-codelab/src/index.js
@@ -731,6 +731,7 @@ export function onBlocksChange() {
     );
 
     if (otherClasses.length > 0) {
+      const viewport = captureWorkspaceViewport(ws);
       // Pass 1 — propagate from active class outward.
       for (const cls of otherClasses) {
         silentGenerateForClass(cls);
@@ -744,6 +745,7 @@ export function onBlocksChange() {
       IdeBridge.selected_file_name = activeClass + '.java';
       setClassName(activeClass);
       load(ws);
+      restoreWorkspaceViewport(ws, viewport);
 
       // Re-generate the active class now that all downstream hints are fresh.
       LocalStorageManager.clearConstructors(activeClass);
@@ -793,6 +795,25 @@ function onXmlLoaded(xhttp) {
  */
 function generateCode() {
   return javaGenerator.workspaceToCode(ws);
+}
+
+function captureWorkspaceViewport(workspace) {
+  if (!workspace) return null;
+  return {
+    scrollX: workspace.scrollX,
+    scrollY: workspace.scrollY,
+    scale: typeof workspace.getScale === 'function' ? workspace.getScale() : workspace.scale,
+  };
+}
+
+function restoreWorkspaceViewport(workspace, viewport) {
+  if (!workspace || !viewport) return;
+  if (typeof workspace.setScale === 'function' && typeof viewport.scale === 'number') {
+    workspace.setScale(viewport.scale);
+  }
+  if (typeof workspace.scroll === 'function') {
+    workspace.scroll(viewport.scrollX, viewport.scrollY);
+  }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
This PR delivers significant improvements to workspace stability, variable scoping, and mutator usability. It fixes critical canvas-jumping issues during workspace changes, prevents parameter variable collisions across different methods, and adds runtime patches to Blockly core to make mutator interactions smoother.

---

### 🐛 Bug Fixes

#### Workspace & Viewport Stability
- **Fixed Canvas Jumping (#139)**: Captures and restores the workspace viewport (scroll position and scale) during class changes (`onBlocksChange`) to prevent scrolling loss and canvas jumping.
- **Scrollbar Metrics Optimization**: Prevented canvas jumping by only updating workspace translation metrics when the scrollbar ratio changes.

#### Scoping & Parameter Collisions
- **Unique Parameter Identification**: Resolved variable name collisions in constructors and methods by backing parameters with uniquely generated internal IDs (`paramIds_`) rather than mapping only by name.
- **Isolated Workspace Variables**: Parameters with the same name in different constructors/methods now map to distinct workspace variables, preventing conflicts inside Blockly's global `VariableMap`.
- **Scoped Type Inference**: Rewrote method parameter type inference to scan only the descendants and workspace block structures within the specific method's body. This eliminates cross-method type contamination where a parameter in one method was incorrectly typed by a parameter in another.

#### Mutator Usability
- **Ignored Intermediate Input Events**: Ignored `BLOCK_FIELD_INTERMEDIATE_CHANGE` events in the mutator to avoid premature recompositions during active typing.
- **Debounced Recomposition**: Added a 300 ms debounce delay to the mini-workspace change listeners inside the mutator. Rapid keystrokes inside `FieldTextInput` are now batched into a single recomposition to prevent the mutator bubble from closing mid-edit.

---

### ✨ Features & Improvements

#### Mutator & Bubble Lifecycle
- **Improved Bubble Close Behavior**: Patched `hideChaff` to automatically close all active mutator and comment bubbles when clicking outside on the main workspace.
- **Click Protection**: Tracked the last pointerdown/mousedown targets to ensure bubbles are not closed if the user clicks anywhere inside the bubble canvas (`.blocklyBubbleCanvas`).

---

### ⚙️ Refactoring & Cleanups

- **Centralized Call Mutators**: Extracted `decomposeCallArg` and `composeCallArg` into shared utilities reused by both regular method call blocks and graphics (`gfx_new_group`) blocks to eliminate code duplication.
- **Centralized Method Initialization**: Consolidated block setup code for static and instance methods with a unified `initMethodBlock` helper.
- **Unified Variable Flyouts**: Extracted the variable list generation into a shared `fillVariableFlyout` helper, cleaning up duplicated XML construction code for normal attributes, local variables, and static attributes.

---

### 🛠️ Developer Tooling

- **VS Code Chrome Debugging**: Updated `.vscode/launch.json` to launch Chrome in `--incognito` mode to prevent cache issues or browser extensions from interfering with the local development server.

