### PR TITLE
disable server ssh deployment

### DIFF
--- a/.github/workflows/deploy_docker.yml
+++ b/.github/workflows/deploy_docker.yml
@@ -96,7 +96,8 @@ jobs:
           done
 
       - name: Deploy on server via SSH (pull image and restart container)
-        if: github.event_name == 'release'
+        if: false 
+        #if:github.event_name == 'release'
         uses: appleboy/ssh-action@v0.1.7
         with:
           host: ${{ vars.DEPLOY_HOST }}

--- a/custom-generator-codelab/src/datenschutz.html
+++ b/custom-generator-codelab/src/datenschutz.html
@@ -306,7 +306,7 @@
         rechtlichen Anforderungen zu entsprechen. Die jeweils aktuelle Version ist unter dieser URL abrufbar.
       </p>
 
-      <p><em>Stand: März 2026</em></p>
+      <p><em>Stand: Juni 2026</em></p>
     </div>
   </main>
 


### PR DESCRIPTION
Reduce load on the VPS. App is successfully deployed via cloudflare (https://blockly2java.de) and github as fallback (https://valentinherrmann.github.io/Blockly2Java)