### PR TITLE
 add dimension selection to the empty array/list block and support FilledShape 

### DIFF
--- a/custom-generator-codelab/src/blocks/arrays.js
+++ b/custom-generator-codelab/src/blocks/arrays.js
@@ -37,7 +37,7 @@ Blockly.Blocks['lists_repeat'] = {
     }
 
     const defaultTypes = [
-      'int', 'double', 'boolean', 'String', 'Actor', 'Shape', 'Circle',
+      'int', 'double', 'boolean', 'String', 'Actor', 'Shape', 'FilledShape', 'Circle',
       'Ellipse', 'Rectangle', 'RoundedRectangle', 'Triangle', 'Line',
       'Text', 'Turtle', 'Group', 'Bitmap', 'Polygon'
     ];

--- a/custom-generator-codelab/src/blocks/arrays.js
+++ b/custom-generator-codelab/src/blocks/arrays.js
@@ -4,9 +4,15 @@ import LocalStorageManager from '../utils/LocalStorageManager';
 Blockly.Blocks['lists_repeat'] = {
   init: function() {
     const dropdown = new Blockly.FieldDropdown(() => this.getTypeOptions_());
+    const dimDropdown = new Blockly.FieldDropdown(() => [
+      ['[ ]', '[]'],
+      ['[ ][ ] (2 dimensional)', '[][]']
+    ]);
     this.appendDummyInput()
         .appendField(Blockly.Msg["LISTS_REPEAT_TITLE_TYPE"] || 'erzeuge Array vom Typ')
         .appendField(dropdown, 'TYPE')
+        .appendField(' ')
+        .appendField(dimDropdown, 'DIM')
         .appendField(Blockly.Msg["LISTS_REPEAT_TITLE_LENGTH"] || 'mit Länge');
     this.appendValueInput('NUM')
         .setCheck('Number');
@@ -16,13 +22,13 @@ Blockly.Blocks['lists_repeat'] = {
     this.setTooltip(Blockly.Msg["LISTS_REPEAT_TOOLTIP"] || 'Erzeugt ein Array mit der angegebenen Länge ohne Werte.');
   },
   getTypeOptions_: function() {
-    const options = [];
+    const baseTypes = [];
     try {
       const allCtrs = LocalStorageManager.getAllConstructors();
       if (allCtrs) {
         for (const name of Object.keys(allCtrs)) {
-          if (name && !options.some(opt => opt[1] === name)) {
-            options.push([name, name]);
+          if (name && !baseTypes.includes(name)) {
+            baseTypes.push(name);
           }
         }
       }
@@ -31,38 +37,45 @@ Blockly.Blocks['lists_repeat'] = {
     }
 
     const defaultTypes = [
-      ['int', 'int'],
-      ['double', 'double'],
-      ['boolean', 'boolean'],
-      ['String', 'String'],
-      ['Actor', 'Actor'],
-      ['Shape', 'Shape'],
-      ['Circle', 'Circle'],
-      ['Ellipse', 'Ellipse'],
-      ['Rectangle', 'Rectangle'],
-      ['RoundedRectangle', 'RoundedRectangle'],
-      ['Triangle', 'Triangle'],
-      ['Line', 'Line'],
-      ['Text', 'Text'],
-      ['Turtle', 'Turtle'],
-      ['Group', 'Group'],
-      ['Bitmap', 'Bitmap'],
-      ['Polygon', 'Polygon']
+      'int', 'double', 'boolean', 'String', 'Actor', 'Shape', 'Circle',
+      'Ellipse', 'Rectangle', 'RoundedRectangle', 'Triangle', 'Line',
+      'Text', 'Turtle', 'Group', 'Bitmap', 'Polygon'
     ];
 
-    for (const opt of defaultTypes) {
-      if (!options.some(existing => existing[1] === opt[1])) {
-        options.push(opt);
+    for (const type of defaultTypes) {
+      if (!baseTypes.includes(type)) {
+        baseTypes.push(type);
       }
+    }
+
+    const options = [];
+    for (const type of baseTypes) {
+      options.push([type, type]);
     }
     return options;
   },
   saveExtraState: function() {
-    return { typeValue: this.getFieldValue('TYPE') };
+    return {
+      typeValue: this.getFieldValue('TYPE'),
+      dimValue: this.getFieldValue('DIM')
+    };
   },
   loadExtraState: function(state) {
-    const val = state?.typeValue;
+    let val = state?.typeValue;
+    let dimVal = state?.dimValue;
     if (val) {
+      if (!dimVal) {
+        // backward compatibility for when TYPE was e.g. "int[]" or "int[][]"
+        if (val.endsWith('[][]')) {
+          dimVal = '[][]';
+          val = val.slice(0, -4);
+        } else if (val.endsWith('[]')) {
+          dimVal = '[]';
+          val = val.slice(0, -2);
+        } else {
+          dimVal = '[]';
+        }
+      }
       const field = this.getField('TYPE');
       if (field) {
         const origGet = field.getOptions.bind(field);
@@ -75,6 +88,12 @@ Blockly.Blocks['lists_repeat'] = {
         };
         field.setValue(val);
         field.getOptions = origGet;
+      }
+    }
+    if (dimVal) {
+      const dimField = this.getField('DIM');
+      if (dimField) {
+        dimField.setValue(dimVal);
       }
     }
   }

--- a/custom-generator-codelab/src/blocks/lists.js
+++ b/custom-generator-codelab/src/blocks/lists.js
@@ -16,9 +16,15 @@ Blockly.Blocks['list_reverse'] = Blockly.Blocks['lists_reverse'];
 Blockly.Blocks['list_repeat'] = {
   init: function() {
     const dropdown = new Blockly.FieldDropdown(() => this.getTypeOptions_());
+    const dimDropdown = new Blockly.FieldDropdown(() => [
+      ['[ ]', '[]'],
+      ['[ ][ ] (2 dimensional)', '[][]']
+    ]);
     this.appendDummyInput()
         .appendField(Blockly.Msg["LIST_REPEAT_TITLE_TYPE"] || 'erzeuge Liste vom Typ')
         .appendField(dropdown, 'TYPE')
+        .appendField(' ')
+        .appendField(dimDropdown, 'DIM')
         .appendField(Blockly.Msg["LIST_REPEAT_TITLE_LENGTH"] || 'mit Länge');
     this.appendValueInput('NUM')
         .setCheck('Number');
@@ -27,13 +33,13 @@ Blockly.Blocks['list_repeat'] = {
     this.setTooltip(Blockly.Msg["LIST_REPEAT_TOOLTIP"] || 'Erzeugt eine Liste mit der angegebenen Länge ohne Werte.');
   },
   getTypeOptions_: function() {
-    const options = [];
+    const baseTypes = [];
     try {
       const allCtrs = LocalStorageManager.getAllConstructors();
       if (allCtrs) {
         for (const name of Object.keys(allCtrs)) {
-          if (name && !options.some(opt => opt[1] === name)) {
-            options.push([name, name]);
+          if (name && !baseTypes.includes(name)) {
+            baseTypes.push(name);
           }
         }
       }
@@ -42,38 +48,45 @@ Blockly.Blocks['list_repeat'] = {
     }
 
     const defaultTypes = [
-      ['int', 'int'],
-      ['double', 'double'],
-      ['boolean', 'boolean'],
-      ['String', 'String'],
-      ['Actor', 'Actor'],
-      ['Shape', 'Shape'],
-      ['Circle', 'Circle'],
-      ['Ellipse', 'Ellipse'],
-      ['Rectangle', 'Rectangle'],
-      ['RoundedRectangle', 'RoundedRectangle'],
-      ['Triangle', 'Triangle'],
-      ['Line', 'Line'],
-      ['Text', 'Text'],
-      ['Turtle', 'Turtle'],
-      ['Group', 'Group'],
-      ['Bitmap', 'Bitmap'],
-      ['Polygon', 'Polygon']
+      'int', 'double', 'boolean', 'String', 'Actor', 'Shape', 'Circle',
+      'Ellipse', 'Rectangle', 'RoundedRectangle', 'Triangle', 'Line',
+      'Text', 'Turtle', 'Group', 'Bitmap', 'Polygon'
     ];
 
-    for (const opt of defaultTypes) {
-      if (!options.some(existing => existing[1] === opt[1])) {
-        options.push(opt);
+    for (const type of defaultTypes) {
+      if (!baseTypes.includes(type)) {
+        baseTypes.push(type);
       }
+    }
+
+    const options = [];
+    for (const type of baseTypes) {
+      options.push([type, type]);
     }
     return options;
   },
   saveExtraState: function() {
-    return { typeValue: this.getFieldValue('TYPE') };
+    return {
+      typeValue: this.getFieldValue('TYPE'),
+      dimValue: this.getFieldValue('DIM')
+    };
   },
   loadExtraState: function(state) {
-    const val = state?.typeValue;
+    let val = state?.typeValue;
+    let dimVal = state?.dimValue;
     if (val) {
+      if (!dimVal) {
+        // backward compatibility for when TYPE was e.g. "int[]" or "int[][]"
+        if (val.endsWith('[][]')) {
+          dimVal = '[][]';
+          val = val.slice(0, -4);
+        } else if (val.endsWith('[]')) {
+          dimVal = '[]';
+          val = val.slice(0, -2);
+        } else {
+          dimVal = '[]';
+        }
+      }
       const field = this.getField('TYPE');
       if (field) {
         const origGet = field.getOptions.bind(field);
@@ -86,6 +99,12 @@ Blockly.Blocks['list_repeat'] = {
         };
         field.setValue(val);
         field.getOptions = origGet;
+      }
+    }
+    if (dimVal) {
+      const dimField = this.getField('DIM');
+      if (dimField) {
+        dimField.setValue(dimVal);
       }
     }
   }

--- a/custom-generator-codelab/src/blocks/lists.js
+++ b/custom-generator-codelab/src/blocks/lists.js
@@ -48,7 +48,7 @@ Blockly.Blocks['list_repeat'] = {
     }
 
     const defaultTypes = [
-      'int', 'double', 'boolean', 'String', 'Actor', 'Shape', 'Circle',
+      'int', 'double', 'boolean', 'String', 'Actor', 'Shape', 'FilledShape', 'Circle',
       'Ellipse', 'Rectangle', 'RoundedRectangle', 'Triangle', 'Line',
       'Text', 'Turtle', 'Group', 'Bitmap', 'Polygon'
     ];

--- a/custom-generator-codelab/src/generators/javascript/arrays.js
+++ b/custom-generator-codelab/src/generators/javascript/arrays.js
@@ -43,9 +43,15 @@ export function lists_create_with(block, generator) {
 export function lists_repeat(block, generator) {
   // Create an array with specified length but without values in Java.
   const type = block.getFieldValue('TYPE') || 'Object';
+  const dim = block.getFieldValue('DIM') || '[]';
   const repeatCount =
       generator.valueToCode(block, 'NUM', Order.NONE) || '0';
-  const code = 'new ' + type + '[' + repeatCount + ']';
+
+  let bracketCount = 0;
+  if (dim === '[][]') {
+    bracketCount = 1;
+  }
+  const code = 'new ' + type + '[' + repeatCount + ']' + '[]'.repeat(bracketCount);
   return [code, Order.ATOMIC];
 }
 

--- a/custom-generator-codelab/src/generators/javascript/javascript_generator.js
+++ b/custom-generator-codelab/src/generators/javascript/javascript_generator.js
@@ -299,10 +299,15 @@ export function getType(var_type) {
     case 'text_append':
       return TYPES.STRING;
     case 'lists_create_empty': 
+    case 'list_create_empty': 
     case 'lists_create_with': 
+    case 'list_create_with': 
     case 'lists_repeat': 
+    case 'list_repeat': 
     case 'lists_split': 
+    case 'list_split': 
     case 'lists_sort':
+    case 'list_sort':
       return TYPES.LIST;
     case 'logic_null':
       return TYPES.OBJECT;
@@ -493,9 +498,10 @@ export function resolveArgBlockType(argBlock, workspace) {
     const mode = argBlock.getFieldValue('MODE');
     return mode === 'SPLIT' ? 'String[]' : 'String';
   }
-  if (argBlock.type === 'lists_repeat') {
+  if (argBlock.type === 'lists_repeat' || argBlock.type === 'list_repeat') {
     const type = argBlock.getFieldValue('TYPE') || 'Object';
-    return type + '[]';
+    const dim = argBlock.getFieldValue('DIM') || '[]';
+    return type + dim;
   }
   if (argBlock.type === 'lists_getIndex') {
     // Get the VALUE input target. Try real connection first, then fall back to shadow block.

--- a/custom-generator-codelab/src/generators/javascript/lists.js
+++ b/custom-generator-codelab/src/generators/javascript/lists.js
@@ -43,9 +43,15 @@ export function list_create_with(block, generator) {
 export function list_repeat(block, generator) {
   // Create a list with specified length but without values in Java.
   const type = block.getFieldValue('TYPE') || 'Object';
+  const dim = block.getFieldValue('DIM') || '[]';
   const repeatCount =
       generator.valueToCode(block, 'NUM', Order.NONE) || '0';
-  const code = 'new ' + type + '[' + repeatCount + ']';
+
+  let bracketCount = 0;
+  if (dim === '[][]') {
+    bracketCount = 1;
+  }
+  const code = 'new ' + type + '[' + repeatCount + ']' + '[]'.repeat(bracketCount);
   return [code, Order.ATOMIC];
 }
 


### PR DESCRIPTION
  1. Dimension Selection for Empty Array/List Creation:  
      • Introduced a new dropdown selection field ( DIM ) to the repeat/empty array creation blocks ( lists_repeat  and  list_repeat ).
      • Allows users to explicitly choose between creating a 1D array/list ( [ ] ) or a 2D array/list ( [ ][ ] (2 dimensional) ).
      • Updated block generation code ( arrays.js  and  lists.js  generator files) to produce correct Java array initialization syntax depending on the selected dimension (e.g.,  new Type[length]  vs
      new Type[length][] ).
      • Enhanced type inference mechanisms in  javascript_generator.js  ( getType  and  resolveArgBlockType ) to support both the singular/plural block names and resolve the array types using the new
      DIM  field.
      • Preserves backwards compatibility:  loadExtraState  automatically checks if older block states contain trailing brackets in the type string and parses them into the new  DIM  field value     
      accordingly.
  2. Added  FilledShape  Support:
      • Registered  FilledShape  in the list of default type options for creating repeat arrays and lists in both  arrays.js  and  lists.js .
